### PR TITLE
Fix `--help` in clap

### DIFF
--- a/databroker-cli/Cargo.toml
+++ b/databroker-cli/Cargo.toml
@@ -39,6 +39,9 @@ clap = { workspace = true, features = [
     "std",
     "env",
     "derive",
+    "help",
+    "error-context",
+    "usage",
 ] }
 regex = "1.6.0"
 http = "0.2.8"

--- a/databroker/Cargo.toml
+++ b/databroker/Cargo.toml
@@ -45,7 +45,9 @@ tracing-subscriber = { version = "0.3.11", default-features = false, features = 
 clap = { workspace = true, features = [
     "std",
     "env",
-    "derive",
+    "help",
+    "usage",
+    "error-context",
 ] }
 sqlparser = "0.16.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/databroker/src/main.rs
+++ b/databroker/src/main.rs
@@ -171,8 +171,7 @@ async fn read_metadata_file<'a, 'b>(
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let version = option_env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT")
-        .unwrap_or(option_env!("VERGEN_GIT_SHA").unwrap_or("unknown"));
+    let version = option_env!("CARGO_PKG_VERSION").unwrap_or_default();
 
     let about = format!(
         concat!(
@@ -190,7 +189,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         option_env!("VERGEN_CARGO_DEBUG").unwrap_or(""),
     );
 
-    let mut parser = Command::new("Kuksa Data Broker");
+    let mut parser = Command::new("Kuksa Databroker");
     parser = parser
         .version(version)
         .about(about)


### PR DESCRIPTION
This functionality was broken by f38363d4ffc4d50d3ce4d5381112b6c84666e92c, or more specifically with the change to resolver = 2.

The `--help` flag requires a feature in clap to be enabled, which is either a newly introduced requirement, or the feature(s) were somehow included implicitly when using resolver = 1.