### PR TITLE
Delete outdated notice

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,189 +1,27 @@
+# Notices for Eclipse Kuksa
+
+This content is produced and maintained by the Eclipse Kuksa project.
+
+* Project home: <https://projects.eclipse.org/projects/automotive.kuksa>
+
+## Trademarks
+
+ Eclipse Kuksa is a trademark of the Eclipse Foundation.
+
+## Copyright
+
+All content is the property of the respective authors or their employers. For more information regarding authorship of content, please consult the listed source code repository logs.
+
 ## Declared Project Licenses
 
-This program and the accompanying materials are made available under the terms
-of the Apache License 2.0 which is available at
-<https://www.apache.org/licenses/LICENSE-2.0>
+This program and the accompanying materials are made available under the terms of the  Apache License, Version 2.0
+
+You may obtain a copy of the License at
+
+<http://www.apache.org/licenses/LICENSE-2.0>
 
 SPDX-License-Identifier: Apache-2.0
 
-## Contributors
-* Robert Bosch GmbH - initial API and implementation
-* Microsoft Corporation - initial API and implementation
+## Thirdparty Content
 
-## Third-party Content
-
-| Dependency | Version | License |
-|:-----------|:-------:|--------:|
-|aho-corasick|0.7.18|MIT<br/>Unlicense|
-|ansi_term|0.12.1|MIT|
-|anyhow|1.0.56|MIT OR Apache-2.0|
-|arrayref|0.3.6|Simplified BSD|
-|arrayvec|0.5.2|Apache 2.0<br/>MIT|
-|async-stream|0.3.2|MIT|
-|async-stream-impl|0.3.2|MIT|
-|async-trait|0.1.52|MIT OR Apache-2.0|
-|autocfg|1.1.0|Apache-2.0 OR MIT|
-|base64|0.13.0|Apache 2.0<br/>MIT|
-|bitflags|1.3.2|Apache 2.0<br/>MIT|
-|blake2b_simd|0.5.11|MIT|
-|bytes|1.1.0|MIT|
-|cc|1.0.73|Apache 2.0<br/>MIT|
-|cfg-if|0.1.10|Apache 2.0<br/>MIT|
-|cfg-if|1.0.0|Apache 2.0<br/>MIT|
-|clap|3.1.10|MIT OR Apache-2.0|
-|clap_lex|0.1.1|MIT OR Apache-2.0|
-|constant_time_eq|0.1.5|CC0-1.0|
-|crossbeam-utils|0.8.7|MIT OR Apache-2.0|
-|dirs|1.0.5|MIT OR Apache-2.0|
-|dirs|2.0.2|MIT OR Apache-2.0|
-|dirs-sys|0.3.6|MIT OR Apache-2.0|
-|either|1.6.1|Apache 2.0<br/>MIT|
-|enum-iterator|0.7.0|BSD Zero Clause License|
-|enum-iterator-derive|0.7.0|BSD Zero Clause License|
-|fastrand|1.7.0|Apache-2.0 OR MIT|
-|fixedbitset|0.4.1|Apache 2.0<br/>MIT|
-|fnv|1.0.7|MIT<br/>Apache-2.0|
-|form_urlencoded|1.0.1|Apache 2.0<br/>MIT|
-|futures-channel|0.3.21|MIT OR Apache-2.0|
-|futures-core|0.3.21|MIT OR Apache-2.0|
-|futures-sink|0.3.21|MIT OR Apache-2.0|
-|futures-task|0.3.21|MIT OR Apache-2.0|
-|futures-util|0.3.21|MIT OR Apache-2.0|
-|getrandom|0.1.16|MIT OR Apache-2.0|
-|getrandom|0.2.5|MIT OR Apache-2.0|
-|getset|0.1.2|MIT|
-|git2|0.14.0|Apache 2.0<br/>MIT|
-|h2|0.3.11|MIT|
-|hashbrown|0.11.2|Apache 2.0<br/>MIT|
-|heck|0.3.3|MIT OR Apache-2.0|
-|hermit-abi|0.1.19|Apache 2.0<br/>MIT|
-|http|0.2.6|Apache 2.0<br/>MIT|
-|http-body|0.4.4|MIT|
-|httparse|1.6.0|Apache 2.0<br/>MIT|
-|httpdate|1.0.2|Apache 2.0<br/>MIT|
-|hyper|0.14.17|MIT|
-|hyper-timeout|0.4.1|Apache 2.0<br/>MIT|
-|idna|0.2.3|Apache 2.0<br/>MIT|
-|indexmap|1.8.0|Apache 2.0<br/>MIT|
-|instant|0.1.12|New BSD|
-|itertools|0.10.3|Apache 2.0<br/>MIT|
-|itoa|1.0.1|MIT OR Apache-2.0|
-|jobserver|0.1.24|Apache 2.0<br/>MIT|
-|lazy_static|1.4.0|Apache 2.0<br/>MIT|
-|libc|0.2.119|MIT OR Apache-2.0|
-|libgit2-sys|0.13.0+1.4.1|Apache 2.0<br/>MIT|
-|libz-sys|1.1.3|MIT OR Apache-2.0|
-|linefeed|0.6.0|Apache 2.0<br/>MIT|
-|log|0.4.14|MIT OR Apache-2.0|
-|matchers|0.1.0|MIT|
-|matches|0.1.9|MIT|
-|memchr|2.4.1|MIT<br/>Unlicense|
-|mio|0.8.0|MIT|
-|miow|0.3.7|Apache 2.0<br/>MIT|
-|mortal|0.2.2|Apache 2.0<br/>MIT|
-|multimap|0.8.3|Apache 2.0<br/>MIT|
-|nix|0.17.0|MIT|
-|nom|5.1.2|MIT|
-|ntapi|0.3.7|Apache-2.0 OR MIT|
-|num_cpus|1.13.1|MIT OR Apache-2.0|
-|num_threads|0.1.5|MIT OR Apache-2.0|
-|once_cell|1.9.0|MIT OR Apache-2.0|
-|os_str_bytes|6.0.0|MIT OR Apache-2.0|
-|percent-encoding|2.1.0|Apache 2.0<br/>MIT|
-|petgraph|0.6.0|Apache 2.0<br/>MIT|
-|phf|0.8.0|MIT|
-|phf_codegen|0.8.0|MIT|
-|phf_generator|0.8.0|MIT|
-|phf_shared|0.8.0|MIT|
-|pin-project|1.0.10|Apache-2.0 OR MIT|
-|pin-project-internal|1.0.10|Apache-2.0 OR MIT|
-|pin-project-lite|0.2.8|Apache-2.0 OR MIT|
-|pin-utils|0.1.0|MIT OR Apache-2.0|
-|pkg-config|0.3.24|Apache 2.0<br/>MIT|
-|ppv-lite86|0.2.16|Apache 2.0<br/>MIT|
-|proc-macro-error|1.0.4|MIT OR Apache-2.0|
-|proc-macro-error-attr|1.0.4|MIT OR Apache-2.0|
-|proc-macro2|1.0.36|MIT OR Apache-2.0|
-|prost|0.9.0|Apache 2.0|
-|prost-build|0.9.0|Apache 2.0|
-|prost-derive|0.9.0|Apache 2.0|
-|prost-types|0.9.0|Apache 2.0|
-|quote|1.0.15|MIT OR Apache-2.0|
-|rand|0.7.3|MIT OR Apache-2.0|
-|rand|0.8.5|MIT OR Apache-2.0|
-|rand_chacha|0.2.2|MIT OR Apache-2.0|
-|rand_chacha|0.3.1|MIT OR Apache-2.0|
-|rand_core|0.5.1|MIT OR Apache-2.0|
-|rand_core|0.6.3|MIT OR Apache-2.0|
-|rand_hc|0.2.0|Apache 2.0<br/>MIT|
-|rand_pcg|0.2.1|MIT OR Apache-2.0|
-|redox_syscall|0.1.57|MIT|
-|redox_syscall|0.2.10|MIT|
-|redox_users|0.3.5|MIT|
-|redox_users|0.4.0|MIT|
-|regex|1.5.4|MIT OR Apache-2.0|
-|regex-automata|0.1.10|MIT<br/>Unlicense|
-|regex-syntax|0.6.25|Apache 2.0<br/>MIT|
-|remove_dir_all|0.5.3|Apache 2.0<br/>MIT|
-|rust-argon2|0.8.3|Apache 2.0<br/>MIT|
-|rustversion|1.0.6|MIT OR Apache-2.0|
-|ryu|1.0.9|Apache-2.0 OR BSL-1.0|
-|serde|1.0.137|MIT OR Apache-2.0|
-|serde_json|1.0.81|MIT OR Apache-2.0|
-|sharded-slab|0.1.4|MIT|
-|signal-hook-registry|1.4.0|Apache 2.0<br/>MIT|
-|siphasher|0.3.9|Apache 2.0<br/>MIT|
-|slab|0.4.5|MIT|
-|smallstr|0.2.0|Apache 2.0<br/>MIT|
-|smallvec|1.8.0|Apache 2.0<br/>MIT|
-|socket2|0.4.4|MIT OR Apache-2.0|
-|sqlparser|0.16.0|Apache 2.0|
-|syn|1.0.86|MIT OR Apache-2.0|
-|tempfile|3.3.0|MIT OR Apache-2.0|
-|terminfo|0.7.3|WTFPL|
-|textwrap|0.15.0|MIT|
-|thiserror|1.0.30|MIT OR Apache-2.0|
-|thiserror-impl|1.0.30|MIT OR Apache-2.0|
-|thread_local|1.1.4|Apache 2.0<br/>MIT|
-|time|0.3.9|MIT OR Apache-2.0|
-|tinyvec|1.5.1|Zlib OR Apache-2.0 OR MIT|
-|tinyvec_macros|0.1.0|MIT OR Apache-2.0 OR Zlib|
-|tokio|1.17.0|MIT|
-|tokio-io-timeout|1.2.0|Apache 2.0<br/>MIT|
-|tokio-macros|1.7.0|MIT|
-|tokio-stream|0.1.8|MIT|
-|tokio-util|0.6.9|MIT|
-|tokio-util|0.7.0|MIT|
-|tonic|0.6.2|MIT|
-|tonic-build|0.6.2|MIT|
-|tower|0.4.12|MIT|
-|tower-layer|0.3.1|MIT|
-|tower-service|0.3.1|MIT|
-|tracing|0.1.34|MIT|
-|tracing-attributes|0.1.20|MIT|
-|tracing-core|0.1.22|MIT|
-|tracing-futures|0.2.5|MIT|
-|tracing-subscriber|0.3.11|MIT|
-|try-lock|0.2.3|MIT|
-|unicode-bidi|0.3.7|Apache-2.0<br/>MIT|
-|unicode-normalization|0.1.19|Apache 2.0<br/>MIT|
-|unicode-segmentation|1.9.0|Apache 2.0<br/>MIT|
-|unicode-width|0.1.9|Apache 2.0<br/>MIT|
-|unicode-xid|0.2.2|MIT OR Apache-2.0|
-|url|2.2.2|Apache 2.0<br/>MIT|
-|valuable|0.1.0|MIT|
-|vcpkg|0.2.15|Apache 2.0<br/>MIT|
-|databroker-api|0.17.0|Apache 2.0|
-|databroker|0.17.0|Apache 2.0|
-|databroker-cli|0.17.0|Apache 2.0|
-|databroker-examples|0.17.0|Apache 2.0|
-|vergen|7.0.0|MIT OR Apache-2.0|
-|version_check|0.9.4|Apache 2.0<br/>MIT|
-|void|1.0.2|MIT|
-|want|0.3.0|MIT|
-|wasi|0.10.2+wasi-snapshot-preview1|Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT|
-|wasi|0.9.0+wasi-snapshot-preview1|Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT|
-|which|4.2.4|MIT|
-|winapi|0.3.9|Apache 2.0<br/>MIT|
-|winapi-i686-pc-windows-gnu|0.4.0|Apache 2.0<br/>MIT|
-|winapi-x86_64-pc-windows-gnu|0.4.0|Apache 2.0<br/>MIT|
+During build thirdparty components may be included. Databroker is a Rust project, all our dependencies are declared in the project's Cargo files. Depending on the build date and your build environment different transitive dependencies might be included. Artifacts published in this repo contain a list of all components of all components (and their licenses) that have been included in the build process.


### PR DESCRIPTION
NOTICE is outdated and not used anymore

(all required dependencies are seen up-to-date in package manager files, and exact transitive dependencies depend on the build environment, and as such can not be documented in code anyway. For our release artifacts we DO generate sboms, and add them to the artifacts where they belong)