### PR TITLE
Disable sdv.databroker.v1 by default

### DIFF
--- a/databroker-cli/src/cli.rs
+++ b/databroker-cli/src/cli.rs
@@ -52,8 +52,8 @@ pub struct Cli {
     ca_cert: Option<String>,
 
     #[arg(value_enum)]
-    #[clap(long, short = 'p', value_enum, default_value = "sdv-databroker-v1")]
-    protocol: CliAPI,
+    #[clap(long, short = 'p', value_enum, default_value_t = Protocol::KuksaValV1)]
+    protocol: Protocol,
 
     // Sub command
     #[clap(subcommand)]
@@ -77,7 +77,7 @@ impl Cli {
         self.server.clone()
     }
 
-    pub fn get_protocol(&mut self) -> CliAPI {
+    pub fn get_protocol(&mut self) -> Protocol {
         self.protocol
     }
 }
@@ -93,8 +93,10 @@ pub enum Commands {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
-pub enum CliAPI {
+pub enum Protocol {
+    #[clap(name = "kuksa.val.v1")]
     KuksaValV1 = 1,
+    #[clap(name = "sdv.databroker.v1")]
     SdvDatabrokerV1 = 2,
 }
 

--- a/databroker-cli/src/kuksa_cli.rs
+++ b/databroker-cli/src/kuksa_cli.rs
@@ -36,13 +36,13 @@ const TIMEOUT: Duration = Duration::from_millis(500);
 const CLI_COMMANDS: &[(&str, &str, &str)] = &[
     ("connect", "[URI]", "Connect to server"),
     ("get", "<PATH> [[PATH] ...]", "Get signal value(s)"),
-    ("set", "<PATH> <VALUE>", "Set actuator signal"),
+    ("actuate", "<PATH> <VALUE>", "Set actuator signal"),
     (
         "subscribe",
         "<QUERY>",
         "Subscribe to signals with QUERY, if you use kuksa feature comma separated list",
     ),
-    ("feed", "<PATH> <VALUE>", "Publish signal value"),
+    ("publish", "<PATH> <VALUE>", "Publish signal value"),
     (
         "metadata",
         "[PATTERN]",
@@ -318,7 +318,7 @@ pub async fn kuksa_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                                 )?,
                             }
                         }
-                        "set" => {
+                        "actuate" => {
                             interface.add_history_unique(line.clone());
 
                             let (path, value) = cli::split_first_word(args);
@@ -368,9 +368,6 @@ pub async fn kuksa_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                                                 cmd,
                                                 format!("{} is not an actuator.", path),
                                             )?;
-                                            cli::print_info(
-                                                "If you want to provide the signal value, use `feed`.",
-                                            )?;
                                             continue;
                                         }
 
@@ -402,7 +399,7 @@ pub async fn kuksa_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                                 }
                             }
                         }
-                        "feed" => {
+                        "publish" => {
                             interface.add_history_unique(line.clone());
 
                             let (path, value) = cli::split_first_word(args);
@@ -902,7 +899,7 @@ impl<Term: Terminal> Completer<Term> for CliCompleter {
                 Some(compls)
             }
             // Complete command parameters
-            Some("set") | Some("feed") => {
+            Some("actuate") | Some("publish") => {
                 if words.count() == 0 {
                     self.complete_entry_path(word)
                 } else {

--- a/databroker-cli/src/main.rs
+++ b/databroker-cli/src/main.rs
@@ -12,7 +12,7 @@
 ********************************************************************************/
 
 use clap::Parser;
-use cli::CliAPI;
+use cli::Protocol;
 
 pub mod cli;
 mod kuksa_cli;
@@ -21,19 +21,19 @@ mod sdv_cli;
 #[tokio::main]
 async fn main() {
     let mut cli = cli::Cli::parse();
-    if cli.get_protocol() == CliAPI::SdvDatabrokerV1 {
+    if cli.get_protocol() == Protocol::SdvDatabrokerV1 {
         let err = sdv_cli::sdv_main(cli.clone()).await;
         match err {
             Ok(_) => (),
             Err(e) => eprintln!("Error: {}", e),
         }
-    } else if cli.get_protocol() == CliAPI::KuksaValV1 {
+    } else if cli.get_protocol() == Protocol::KuksaValV1 {
         let err = kuksa_cli::kuksa_main(cli.clone()).await;
         match err {
             Ok(_) => (),
             Err(e) => eprintln!("Error: {}", e),
         }
     } else {
-        println!("Choose one protocol of either kuksa-val-v1 or sdv-databroker-v1")
+        println!("Choose one protocol of either kuksa.val.v1 or sdv.databroker.v1")
     }
 }

--- a/databroker-cli/src/sdv_cli.rs
+++ b/databroker-cli/src/sdv_cli.rs
@@ -42,7 +42,7 @@ const CLI_COMMANDS: &[(&str, &str, &str)] = &[
         "<QUERY>",
         "Subscribe to signals with QUERY, if you use kuksa feature comma separated list",
     ),
-    ("feed", "<PATH> <VALUE>", "Publish signal value"),
+    ("publish", "<PATH> <VALUE>", "Publish signal value"),
     (
         "metadata",
         "[PATTERN]",
@@ -351,9 +351,6 @@ pub async fn sdv_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                                         cmd,
                                         format!("{} is not an actuator.", metadata.name),
                                     )?;
-                                    cli::print_info(
-                                        "If you want to provide the signal value, use `feed`.",
-                                    )?;
                                     continue;
                                 }
 
@@ -404,7 +401,7 @@ pub async fn sdv_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                                 }
                             }
                         }
-                        "feed" => {
+                        "publish" => {
                             interface.add_history_unique(line.clone());
 
                             let (path, value) = cli::split_first_word(args);
@@ -916,7 +913,7 @@ impl<Term: Terminal> Completer<Term> for CliCompleter {
                 Some(compls)
             }
             // Complete command parameters
-            Some("set") | Some("feed") => {
+            Some("set") | Some("publish") => {
                 if words.count() == 0 {
                     self.complete_entry_path(word)
                 } else {

--- a/databroker/src/grpc/server.rs
+++ b/databroker/src/grpc/server.rs
@@ -34,6 +34,12 @@ pub enum ServerTLS {
     Enabled { tls_config: ServerTlsConfig },
 }
 
+#[derive(PartialEq)]
+pub enum Api {
+    KuksaValV1,
+    SdvDatabrokerV1,
+}
+
 impl tonic::service::Interceptor for Authorization {
     fn call(
         &mut self,
@@ -93,6 +99,7 @@ pub async fn serve<F>(
     addr: impl Into<std::net::SocketAddr>,
     broker: broker::DataBroker,
     #[cfg(feature = "tls")] server_tls: ServerTLS,
+    apis: &[Api],
     authorization: Authorization,
     signal: F,
 ) -> Result<(), Box<dyn std::error::Error>>
@@ -124,6 +131,7 @@ where
         broker,
         #[cfg(feature = "tls")]
         server_tls,
+        apis,
         authorization,
         signal,
     )
@@ -134,6 +142,7 @@ pub async fn serve_with_incoming_shutdown<F>(
     listener: TcpListener,
     broker: broker::DataBroker,
     #[cfg(feature = "tls")] server_tls: ServerTLS,
+    apis: &[Api],
     authorization: Authorization,
     signal: F,
 ) -> Result<(), Box<dyn std::error::Error>>
@@ -146,7 +155,7 @@ where
     }
 
     let incoming = TcpListenerStream::new(listener);
-    let mut builder = Server::builder()
+    let mut server = Server::builder()
         .http2_keepalive_interval(Some(Duration::from_secs(10)))
         .http2_keepalive_timeout(Some(Duration::from_secs(20)));
 
@@ -154,7 +163,7 @@ where
     match server_tls {
         ServerTLS::Enabled { tls_config } => {
             info!("Using TLS");
-            builder = builder.tls_config(tls_config)?;
+            server = server.tls_config(tls_config)?;
         }
         ServerTLS::Disabled => {
             info!("TLS is not enabled")
@@ -165,23 +174,35 @@ where
         info!("Authorization is not enabled.");
     }
 
-    builder
-        .add_service(
+    let kuksa_val_v1 = {
+        if apis.contains(&Api::KuksaValV1) {
+            Some(kuksa::val::v1::val_server::ValServer::with_interceptor(
+                broker.clone(),
+                authorization.clone(),
+            ))
+        } else {
+            None
+        }
+    };
+
+    let mut router = server.add_optional_service(kuksa_val_v1);
+
+    if apis.contains(&Api::SdvDatabrokerV1) {
+        router = router.add_optional_service(Some(
             sdv::databroker::v1::broker_server::BrokerServer::with_interceptor(
                 broker.clone(),
                 authorization.clone(),
             ),
-        )
-        .add_service(
+        ));
+        router = router.add_optional_service(Some(
             sdv::databroker::v1::collector_server::CollectorServer::with_interceptor(
                 broker.clone(),
-                authorization.clone(),
+                authorization,
             ),
-        )
-        .add_service(kuksa::val::v1::val_server::ValServer::with_interceptor(
-            broker.clone(),
-            authorization,
-        ))
+        ));
+    }
+
+    router
         .serve_with_incoming_shutdown(incoming, shutdown(broker, signal))
         .await?;
 

--- a/databroker/src/main.rs
+++ b/databroker/src/main.rs
@@ -245,6 +245,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .long("disable-authorization")
                 .help("Disable authorization")
                 .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("enable-databroker-v1")
+                .display_order(30)
+                .long("enable-databroker-v1")
+                .help("Enable sdv.databroker.v1 (GRPC) service")
+                .action(ArgAction::SetTrue),
         );
 
     #[cfg(feature = "tls")]
@@ -438,11 +445,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
+    let mut apis = vec![grpc::server::Api::KuksaValV1];
+
+    if args.get_flag("enable-databroker-v1") {
+        apis.push(grpc::server::Api::SdvDatabrokerV1);
+    }
+
     grpc::server::serve(
         addr,
         broker,
         #[cfg(feature = "tls")]
         tls_config,
+        &apis,
         authorization,
         shutdown_handler(),
     )

--- a/databroker/tests/world/mod.rs
+++ b/databroker/tests/world/mod.rs
@@ -232,6 +232,7 @@ impl DataBrokerWorld {
                 data_broker,
                 #[cfg(feature = "tls")]
                 CERTS.server_tls_config(),
+                &[grpc::server::Api::KuksaValV1],
                 _authorization,
                 poll_fn(|cx| {
                     let mut state = owned_state

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -28,7 +28,7 @@ VSS_DATA_DIR="$SCRIPT_DIR/../data"
 
 echo "Starting databroker container (\"${DATABROKER_IMAGE}\") in insecure mode, requesting platform (\"${CONTAINER_PLATFORM}\")"
 RUNNING_IMAGE=$(
-    docker run -d -v ${VSS_DATA_DIR}:/data -p 55555:55555 --rm  --platform ${CONTAINER_PLATFORM} ${DATABROKER_IMAGE} --metadata data/vss-core/vss_release_4.0.json --insecure
+    docker run -d -v ${VSS_DATA_DIR}:/data -p 55555:55555 --rm  --platform ${CONTAINER_PLATFORM} ${DATABROKER_IMAGE} --metadata data/vss-core/vss_release_4.0.json --insecure --enable-databroker-v1
 )
 
 python3 -m pytest -v "${SCRIPT_DIR}/test_databroker.py"


### PR DESCRIPTION
- Disable sdv.databroker.v1 by default. It can be enabled by supplying a flag at startup.
- Change databroker-cli to use kuksa.val.v1 by default.