### PR TITLE
Fix caching on databroker build

### DIFF
--- a/.github/workflows/kuksa_databroker_build.yml
+++ b/.github/workflows/kuksa_databroker_build.yml
@@ -80,7 +80,7 @@ jobs:
             ~/.cargo/.crates.toml
             ~/.cargo/.crates2.json
             ~/.cache/pip/
-            target-*/
+            target/
           key: databroker-coverage-${{ hashFiles('**/Cargo.lock') }}
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
@@ -116,7 +116,7 @@ jobs:
           ~/.cargo/git/db/
           ~/.cargo/.crates.toml
           ~/.cargo/.crates2.json
-          target/
+          target-*/
         key: databroker-release-${{ matrix.platform.name }}-${{ hashFiles('**/Cargo.lock') }}
     - name: Install build prerequisites
       working-directory: ${{github.workspace}}/


### PR DESCRIPTION
There was a typo that prevents full caching of build artifacts for databroker build (CLI was ok already). Fixed now. 

Example build with no cache (so probably also the build here, as changing cache contents invalidates cache)

![Screenshot 2024-05-09 at 13 43 53](https://github.com/eclipse-kuksa/kuksa-databroker/assets/3707124/02d74c7c-df2c-460d-a59c-6d94d2e27314)

Subsequent build satisfying cache requirements

![Screenshot 2024-05-09 at 13 47 12](https://github.com/eclipse-kuksa/kuksa-databroker/assets/3707124/d55f6f88-2844-4363-8f05-944ec4d82903)

(see here https://github.com/boschglobal/kuksa-databroker/actions?query=event%3Apull_request+branch%3Atest%2Fcaching for various test builds)

I also checked where time is mainly used now

 - 20+   sec is always used pulling the cross images (crossb uilds using docker). the cross _cargo_ package is cached and not reinstalled but the docker images are not. **I do not intend to look into this/fix this in this PR**. Just a hint, if somebody feels bored. I am however not sure if there is even a feasible solution as those images are around 2 GB each and I think there are strict limitations on how much cache can be used before things get evicted)
 - Another large chunk is basically the "linking" so I think, this has to be accepted.


