### PR TITLE
Upgrade check-dash action to v4: Faster + auto create tickets

### DIFF
--- a/.github/workflows/kuksa_databroker-cli_build.yml
+++ b/.github/workflows/kuksa_databroker-cli_build.yml
@@ -240,6 +240,7 @@ jobs:
           > ${{github.workspace}}/dash-databrokercli-deps
 
       - name: Dash license check
-        uses: eclipse-kuksa/kuksa-actions/check-dash@3
+        uses: eclipse-kuksa/kuksa-actions/check-dash@4
         with:
           dashinput: ${{github.workspace}}/dash-databrokercli-deps
+          dashtoken: ${{ secrets.ECLIPSE_GITLAB_API_TOKEN }}

--- a/.github/workflows/kuksa_databroker_build.yml
+++ b/.github/workflows/kuksa_databroker_build.yml
@@ -294,6 +294,7 @@ jobs:
           > ${{github.workspace}}/dash-databroker-deps
 
       - name: Dash license check
-        uses: eclipse-kuksa/kuksa-actions/check-dash@3
+        uses: eclipse-kuksa/kuksa-actions/check-dash@4
         with:
           dashinput: ${{github.workspace}}/dash-databroker-deps
+          dashtoken: ${{ secrets.ECLIPSE_GITLAB_API_TOKEN }}


### PR DESCRIPTION
This allows dash to create tickets in Eclipses IP tracker if necessary

It is also faster then the old version, as installation time for JVM is greatly reduced

Before

<img width="347" alt="image" src="https://github.com/eclipse-kuksa/kuksa-databroker/assets/3707124/233289a0-b91c-48a8-a9ad-3272dbc1d1ff">

After

<img width="350" alt="image" src="https://github.com/eclipse-kuksa/kuksa-databroker/assets/3707124/b0de5949-3b3b-4f5d-8c3b-89f76ec55ab7">
