### PR TITLE
Upgrading codecov dependency

### DIFF
--- a/.github/workflows/kuksa_databroker_build.yml
+++ b/.github/workflows/kuksa_databroker_build.yml
@@ -87,11 +87,11 @@ jobs:
       - name: Generate code coverage
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
-        # To use v4 a token must be specifed by "token: ${{ secrets.CODECOV_TOKEN }}""
         # Uploaded result available at https://app.codecov.io/gh/eclipse-kuksa/kuksa-databroker
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   build:
     name: Build


### PR DESCRIPTION
Seems to be working. Well - upload does not work due to a limit for tokenless update, likely same problem as we often see for v3. Will do a retry tomorrow morning when it maybe is lower load as the Americans are sleeping.

_It is MAYBE so that we could add a token to the fork, but we cannot expect that all forks have a suitable token, and it seems to imply that we enable codecov for that particular organization_


`
error - 2024-05-13 14:46:53,425 -- Report creating failed: {"detail":"Tokenless has reached GitHub rate limit. Please upload using a token: https://docs.codecov.com/docs/adding-the-codecov-token. Expected available in 924 seconds."}`