### PR TITLE
Add StreamedUpdate API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,7 +540,7 @@ dependencies = [
  "globwalk",
  "humantime",
  "inventory",
- "itertools 0.12.1",
+ "itertools",
  "lazy-regex",
  "linked-hash-map",
  "once_cell",
@@ -560,7 +560,7 @@ checksum = "01091e28d1f566c8b31b67948399d2efd6c0a8f6228a9785519ed7b73f7f0aef"
 dependencies = [
  "cucumber-expressions",
  "inflections",
- "itertools 0.12.1",
+ "itertools",
  "proc-macro2",
  "quote",
  "regex",
@@ -1695,15 +1695,6 @@ checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
@@ -2241,12 +2232,12 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.1.25"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 1.0.109",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2266,9 +2257,9 @@ checksum = "744a264d26b88a6a7e37cbad97953fa233b94d585236310bcbc88474b4092d79"
 
 [[package]]
 name = "prost"
-version = "0.11.9"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2276,44 +2267,43 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.9"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
+checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
- "itertools 0.10.5",
- "lazy_static",
+ "heck 0.5.0",
+ "itertools",
  "log",
  "multimap",
+ "once_cell",
  "petgraph",
  "prettyplease",
  "prost",
  "prost-types",
  "regex",
- "syn 1.0.109",
+ "syn 2.0.60",
  "tempfile",
- "which",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.11.9"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.11.9"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
  "prost",
 ]
@@ -2510,32 +2500,42 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
  "ring",
+ "rustls-pki-types",
  "rustls-webpki",
- "sct",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.4"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.0",
+ "rustls-pki-types",
 ]
 
 [[package]]
-name = "rustls-webpki"
-version = "0.101.7"
+name = "rustls-pki-types"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
 dependencies = [
  "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -2565,16 +2565,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "sd-notify"
@@ -2790,6 +2780,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
@@ -3017,11 +3013,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
  "rustls",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -3065,17 +3062,15 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
 dependencies = [
  "async-stream",
  "async-trait",
  "axum",
  "base64 0.21.7",
  "bytes",
- "futures-core",
- "futures-util",
  "h2",
  "http",
  "http-body",
@@ -3085,6 +3080,7 @@ dependencies = [
  "pin-project",
  "prost",
  "rustls-pemfile",
+ "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -3096,15 +3092,15 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.8.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
+checksum = "be4ef6dd70a610078cb4e338a0f79d06bc759ff1b22d2120c2ff02ae264ba9c2"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3422,18 +3418,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
-]
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3620,3 +3604,9 @@ checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,6 +615,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
+ "tonic-mock",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -3101,6 +3102,20 @@ dependencies = [
  "prost-build",
  "quote",
  "syn 2.0.60",
+]
+
+[[package]]
+name = "tonic-mock"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea9163cf065e21bf30e5ad1789bf334f5ae67e4a25f0e8200a7e375466e755ea"
+dependencies = [
+ "bytes",
+ "futures",
+ "http",
+ "http-body",
+ "prost",
+ "tonic",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,15 +29,15 @@ exclude = [
 clap = { version = "4.2", default-features = false }
 databroker-proto = { path = "databroker-proto" }
 # prost has no features
-prost = "0.11"
+prost = "0.12.6"
 # prost-types has no features
-prost-types = "0.11"
+prost-types = "0.12.6"
 # tokio does not enable features by default
 tokio = "1.17.0"
 # tokio-stream has no features
 tokio-stream = "0.1.8"
-tonic = { version = "0.9.1", default-features = false }
-tonic-build = { version = "0.8", default-features = false }
+tonic = { version = "0.11.0", default-features = false }
+tonic-build = { version = "0.11.0", default-features = false }
 
 [profile.release]
 lto = true                 # Link time optimization (dead code removal etc...)

--- a/databroker-cli/src/kuksa_cli.rs
+++ b/databroker-cli/src/kuksa_cli.rs
@@ -349,13 +349,13 @@ pub async fn kuksa_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                                     if let Some(metadata) = entry.metadata {
                                         let data_value = try_into_data_value(
                                             value,
-                                            proto::v1::DataType::from_i32(metadata.data_type)
+                                            proto::v1::DataType::try_from(metadata.data_type)
                                                 .unwrap(),
                                         );
                                         if data_value.is_err() {
                                             println!(
                                                 "Could not parse \"{value}\" as {:?}",
-                                                proto::v1::DataType::from_i32(metadata.data_type)
+                                                proto::v1::DataType::try_from(metadata.data_type)
                                                     .unwrap()
                                             );
                                             continue;
@@ -430,14 +430,14 @@ pub async fn kuksa_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                                     if let Some(metadata) = entry.metadata {
                                         let data_value = try_into_data_value(
                                             value,
-                                            proto::v1::DataType::from_i32(metadata.data_type)
+                                            proto::v1::DataType::try_from(metadata.data_type)
                                                 .unwrap(),
                                         );
                                         if data_value.is_err() {
                                             println!(
                                                 "Could not parse \"{}\" as {:?}",
                                                 value,
-                                                proto::v1::DataType::from_i32(metadata.data_type)
+                                                proto::v1::DataType::try_from(metadata.data_type)
                                                     .unwrap()
                                             );
                                             continue;
@@ -683,14 +683,16 @@ pub async fn kuksa_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                                                         "{:<max_len_path$} {:<10} {:<9}",
                                                         entry.path,
                                                         DisplayEntryType::from(
-                                                            proto::v1::EntryType::from_i32(
+                                                            proto::v1::EntryType::try_from(
                                                                 entry_metadata.entry_type
                                                             )
+                                                            .ok()
                                                         ),
                                                         DisplayDataType::from(
-                                                            proto::v1::DataType::from_i32(
+                                                            proto::v1::DataType::try_from(
                                                                 entry_metadata.data_type
                                                             )
+                                                            .ok()
                                                         ),
                                                     );
                                                 } else {

--- a/databroker-cli/src/sdv_cli.rs
+++ b/databroker-cli/src/sdv_cli.rs
@@ -336,12 +336,12 @@ pub async fn sdv_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                             if let Some(metadata) = datapoint_metadata {
                                 let data_value = try_into_data_value(
                                     value,
-                                    proto::v1::DataType::from_i32(metadata.data_type).unwrap(),
+                                    proto::v1::DataType::try_from(metadata.data_type).unwrap(),
                                 );
                                 if data_value.is_err() {
                                     println!(
                                         "Could not parse \"{value}\" as {:?}",
-                                        proto::v1::DataType::from_i32(metadata.data_type).unwrap()
+                                        proto::v1::DataType::try_from(metadata.data_type).unwrap()
                                     );
                                     continue;
                                 }
@@ -369,8 +369,8 @@ pub async fn sdv_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                                             cli::print_resp_ok(cmd)?;
                                         } else {
                                             for (id, error) in message.errors {
-                                                match proto::v1::DatapointError::from_i32(error) {
-                                                    Some(error) => {
+                                                match proto::v1::DatapointError::try_from(error) {
+                                                    Ok(error) => {
                                                         cli::print_resp_ok(cmd)?;
                                                         println!(
                                                             "Error setting {}: {}",
@@ -378,7 +378,7 @@ pub async fn sdv_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                                                             Color::Red.paint(format!("{error:?}")),
                                                         );
                                                     }
-                                                    None => cli::print_resp_ok_fmt(
+                                                    Err(_) => cli::print_resp_ok_fmt(
                                                         cmd,
                                                         format_args!("Error setting id {id}"),
                                                     )?,
@@ -431,13 +431,13 @@ pub async fn sdv_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                             if let Some(metadata) = datapoint_metadata {
                                 let data_value = try_into_data_value(
                                     value,
-                                    proto::v1::DataType::from_i32(metadata.data_type).unwrap(),
+                                    proto::v1::DataType::try_from(metadata.data_type).unwrap(),
                                 );
                                 if data_value.is_err() {
                                     println!(
                                         "Could not parse \"{}\" as {:?}",
                                         value,
-                                        proto::v1::DataType::from_i32(metadata.data_type).unwrap()
+                                        proto::v1::DataType::try_from(metadata.data_type).unwrap()
                                     );
                                     continue;
                                 }
@@ -461,14 +461,14 @@ pub async fn sdv_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                                                 } else {
                                                     format!("id {id}")
                                                 };
-                                                match proto::v1::DatapointError::from_i32(error) {
-                                                    Some(error) => cli::print_resp_ok_fmt(
+                                                match proto::v1::DatapointError::try_from(error) {
+                                                    Ok(error) => cli::print_resp_ok_fmt(
                                                         cmd,
                                                         format_args!(
                                                             "Error providing {identifier}: {error:?}",
                                                         ),
                                                     )?,
-                                                    None => cli::print_resp_ok_fmt(
+                                                    Err(_) => cli::print_resp_ok_fmt(
                                                         cmd,
                                                         format_args!("Error providing {identifier}",),
                                                     )?,
@@ -723,12 +723,12 @@ pub async fn sdv_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                                     println!(
                                         "{:<max_len_path$} {:<10} {:<9}",
                                         entry.name,
-                                        DisplayEntryType::from(proto::v1::EntryType::from_i32(
-                                            entry.entry_type
-                                        )),
-                                        DisplayDataType::from(proto::v1::DataType::from_i32(
-                                            entry.data_type
-                                        )),
+                                        DisplayEntryType::from(
+                                            proto::v1::EntryType::try_from(entry.entry_type).ok()
+                                        ),
+                                        DisplayDataType::from(
+                                            proto::v1::DataType::try_from(entry.data_type).ok()
+                                        ),
                                     );
                                 }
                             }
@@ -968,7 +968,7 @@ impl fmt::Display for DisplayDatapoint {
                 proto::v1::datapoint::Value::BoolValue(value) => f.pad(&format!("{value}")),
                 proto::v1::datapoint::Value::FailureValue(failure) => f.pad(&format!(
                     "( {:?} )",
-                    proto::v1::datapoint::Failure::from_i32(*failure).unwrap()
+                    proto::v1::datapoint::Failure::try_from(*failure).unwrap()
                 )),
                 proto::v1::datapoint::Value::Int32Value(value) => f.pad(&format!("{value}")),
                 proto::v1::datapoint::Value::Int64Value(value) => f.pad(&format!("{value}")),

--- a/databroker/Cargo.toml
+++ b/databroker/Cargo.toml
@@ -88,6 +88,7 @@ vergen = { version = "8", features = [
 anyhow = "1.0"
 chrono = "^0.4"
 cucumber = { version = "0.20", default-features = false, features = ["libtest", "macros"] }
+tonic-mock = "0.3.0"
 
 [[test]]
 name = "read_write_values"

--- a/databroker/src/broker.rs
+++ b/databroker/src/broker.rs
@@ -726,7 +726,7 @@ impl ChangeSubscription {
                                                 notify_fields.insert(Field::ActuatorTarget);
                                             }
                                             // fill unit field always
-                                            update.unit = entry.metadata.unit.clone();
+                                            update.unit.clone_from(&entry.metadata.unit);
                                             notifications.updates.push(ChangeNotification {
                                                 update,
                                                 fields: notify_fields,
@@ -1431,7 +1431,7 @@ impl<'a, 'b> AuthorizedAccess<'a, 'b> {
             {
                 Ok(None) => false,
                 Ok(Some(lag_updates_)) => {
-                    lag_updates = lag_updates_.clone();
+                    lag_updates.clone_from(&lag_updates_);
                     false
                 }
                 Err(_) => true, // Cleanup needed

--- a/databroker/src/grpc/kuksa_val_v1/val.rs
+++ b/databroker/src/grpc/kuksa_val_v1/val.rs
@@ -275,7 +275,7 @@ impl proto::val_server::Val for broker::DataBroker {
     }
 
     type StreamedUpdateStream =
-    ReceiverStream<Result<proto::StreamedUpdateResponse, tonic::Status>>;
+        ReceiverStream<Result<proto::StreamedUpdateResponse, tonic::Status>>;
 
     async fn streamed_update(
         &self,
@@ -415,10 +415,10 @@ impl proto::val_server::Val for broker::DataBroker {
 
     type SubscribeStream = Pin<
         Box<
-            dyn Stream<Item=Result<proto::SubscribeResponse, tonic::Status>>
-            + Send
-            + Sync
-            + 'static,
+            dyn Stream<Item = Result<proto::SubscribeResponse, tonic::Status>>
+                + Send
+                + Sync
+                + 'static,
         >,
     >;
 
@@ -840,9 +840,9 @@ impl broker::EntryUpdate {
 
 #[cfg(test)]
 mod tests {
-    use databroker_proto::kuksa::val::v1::val_server::Val;
     use super::*;
     use crate::{broker::DataBroker, permissions};
+    use databroker_proto::kuksa::val::v1::val_server::Val;
 
     #[tokio::test]
     async fn test_update_datapoint_using_wrong_type() {
@@ -918,23 +918,24 @@ mod tests {
             .expect("Register datapoint should succeed");
 
         let streamed_update_request = proto::StreamedUpdateRequest {
-            updates: vec![
-                proto::EntryUpdate {
-                    fields: vec![proto::Field::Value as i32],
-                    entry: Some(proto::DataEntry {
-                        path: "Vehicle.Speed".to_owned(),
-                        value: Some(proto::Datapoint {
-                            timestamp: Some(std::time::SystemTime::now().into()),
-                            value: Some(proto::datapoint::Value::Float(120.0)),
-                        }),
-                        metadata: None,
-                        actuator_target: None,
+            updates: vec![proto::EntryUpdate {
+                fields: vec![proto::Field::Value as i32],
+                entry: Some(proto::DataEntry {
+                    path: "Vehicle.Speed".to_owned(),
+                    value: Some(proto::Datapoint {
+                        timestamp: Some(std::time::SystemTime::now().into()),
+                        value: Some(proto::datapoint::Value::Float(120.0)),
                     }),
-                }],
+                    metadata: None,
+                    actuator_target: None,
+                }),
+            }],
         };
 
         let mut streaming_request = tonic_mock::streaming_request(vec![streamed_update_request]);
-        streaming_request.extensions_mut().insert(permissions::ALLOW_ALL.clone());
+        streaming_request
+            .extensions_mut()
+            .insert(permissions::ALLOW_ALL.clone());
         match broker.streamed_update(streaming_request).await {
             Ok(response) => {
                 tokio::spawn(async move {
@@ -955,23 +956,24 @@ mod tests {
         let broker = DataBroker::default();
 
         let streamed_update_request = proto::StreamedUpdateRequest {
-            updates: vec![
-                proto::EntryUpdate {
-                    fields: vec![proto::Field::Value as i32],
-                    entry: Some(proto::DataEntry {
-                        path: "Vehicle.Invalid.Speed".to_owned(),
-                        value: Some(proto::Datapoint {
-                            timestamp: Some(std::time::SystemTime::now().into()),
-                            value: Some(proto::datapoint::Value::Float(120.0)),
-                        }),
-                        metadata: None,
-                        actuator_target: None,
+            updates: vec![proto::EntryUpdate {
+                fields: vec![proto::Field::Value as i32],
+                entry: Some(proto::DataEntry {
+                    path: "Vehicle.Invalid.Speed".to_owned(),
+                    value: Some(proto::Datapoint {
+                        timestamp: Some(std::time::SystemTime::now().into()),
+                        value: Some(proto::datapoint::Value::Float(120.0)),
                     }),
-                }],
+                    metadata: None,
+                    actuator_target: None,
+                }),
+            }],
         };
 
         let mut streaming_request = tonic_mock::streaming_request(vec![streamed_update_request]);
-        streaming_request.extensions_mut().insert(permissions::ALLOW_ALL.clone());
+        streaming_request
+            .extensions_mut()
+            .insert(permissions::ALLOW_ALL.clone());
         match broker.streamed_update(streaming_request).await {
             Ok(response) => {
                 tokio::spawn(async move {

--- a/databroker/src/grpc/kuksa_val_v1/val.rs
+++ b/databroker/src/grpc/kuksa_val_v1/val.rs
@@ -707,7 +707,7 @@ fn proto_entry_from_entry_and_fields(
         }
         if all || fields.contains(&proto::Field::MetadataUnit) {
             metadata_is_set = true;
-            metadata.unit = entry.metadata().unit.clone();
+            metadata.unit.clone_from(&entry.metadata().unit);
         }
         if all || fields.contains(&proto::Field::MetadataValueRestriction) {
             metadata_is_set = true;

--- a/databroker/src/grpc/kuksa_val_v1/val.rs
+++ b/databroker/src/grpc/kuksa_val_v1/val.rs
@@ -25,6 +25,7 @@ use tokio_stream::Stream;
 use tokio_stream::StreamExt;
 use tonic::{Response, Status, Streaming};
 use tracing::debug;
+use tracing::info;
 
 use crate::broker;
 use crate::broker::ReadError;
@@ -304,6 +305,7 @@ impl proto::val_server::Val for broker::DataBroker {
         let (sender, receiver) = mpsc::channel(10);
         // Listening on stream
         tokio::spawn(async move {
+            info!("Update Stream opened");
             let permissions = permissions;
             let broker = broker.authorized_access(&permissions);
             loop {

--- a/databroker/src/grpc/sdv_databroker_v1/collector.rs
+++ b/databroker/src/grpc/sdv_databroker_v1/collector.rs
@@ -196,10 +196,10 @@ impl proto::collector_server::Collector for broker::DataBroker {
 
         for metadata in request.into_inner().list {
             match (
-                proto::DataType::from_i32(metadata.data_type),
-                proto::ChangeType::from_i32(metadata.change_type),
+                proto::DataType::try_from(metadata.data_type),
+                proto::ChangeType::try_from(metadata.change_type),
             ) {
-                (Some(value_type), Some(change_type)) => {
+                (Ok(value_type), Ok(change_type)) => {
                     match broker
                         .add_entry(
                             metadata.name.clone(),
@@ -239,7 +239,7 @@ impl proto::collector_server::Collector for broker::DataBroker {
                         }
                     };
                 }
-                (None, _) => {
+                (Err(_), _) => {
                     // Invalid data type
                     error = Some(Status::new(
                         Code::InvalidArgument,
@@ -247,7 +247,7 @@ impl proto::collector_server::Collector for broker::DataBroker {
                     ));
                     break;
                 }
-                (_, None) => {
+                (_, Err(_)) => {
                     // Invalid change type
                     error = Some(Status::new(
                         Code::InvalidArgument,

--- a/databroker/tests/read_write_values.rs
+++ b/databroker/tests/read_write_values.rs
@@ -213,7 +213,7 @@ fn assert_value(
             };
             match data_entry
                 .metadata
-                .and_then(|m| DataType::from_i32(m.data_type))
+                .and_then(|m| DataType::try_from(m.data_type).ok())
             {
                 None => panic!("no metadata for path: {:?}", path),
                 Some(actual_type) => assert_eq!(actual_type, expected_type),

--- a/databroker/tests/world/mod.rs
+++ b/databroker/tests/world/mod.rs
@@ -267,7 +267,7 @@ impl DataBrokerWorld {
 
         debug!("started Databroker [address: {addr}]");
 
-        let data_broker_url = format!("http://{}:{}", addr.ip(), addr.port());
+        let data_broker_url = format!("https://{}:{}", addr.ip(), addr.port());
 
         self.broker_client = match kuksa_common::to_uri(data_broker_url.clone()) {
             Ok(uri) => Some(kuksa::KuksaClient::new(uri)),

--- a/doc/tls.md
+++ b/doc/tls.md
@@ -63,14 +63,14 @@ so if running KUKSA Databroker from a default container you need to mount the di
 Can be run in TLS mode like below.
 
 ```
-~/kuksa.val/kuksa_databroker$ cargo run --bin databroker-cli -- --ca-cert ../certificates/CA.pem
+~/kuksa.val/kuksa_databroker$ cargo run --bin databroker-cli -- --ca-cert ../certificates/CA.pem --server https://127.0.0.1:55555
 ```
 
 Default certificates and keys are not included in the default KUKSA Databroker-cli container,
 so if running KUKSA Databroker-cli from a default container you need to mount the directory containing the keys and certificates.
 
 ```
-docker run --rm -it --net=host -v /home/user/kuksa.val/certificates:/certs databroker-cli --ca-cert /certs/CA.pem
+docker run --rm -it --net=host -v /home/user/kuksa.val/certificates:/certs databroker-cli --ca-cert /certs/CA.pem --server https://127.0.0.1:55555
 ```
 
 ## KUKSA Client (command line)

--- a/doc/user_guide.md
+++ b/doc/user_guide.md
@@ -129,11 +129,14 @@ The command below starts the Databroker using the example key and certificate fr
 docker run --rm -it --name Server --network kuksa -v ./certificates:/opt/kuksa ghcr.io/eclipse-kuksa/kuksa-databroker:main --tls-cert /opt/kuksa/Server.pem --tls-private-key /opt/kuksa/Server.key
 ```
 
+It is mandatory to correctly qualify the Databroker URL with `https://` protocol when the Databroker has an active TLS configuration.
+The `databroker-cli` uses `http://127.0.0.1:55555` as a default value therefore it is required to specify the `--server` flag (e.g. `--server https://127.0.0.1:55555`) when connecting from databroker-cli to a Databroker with an active TLS configuration.
+
 The CLI can then be configured to use a corresponding trusted CA certificate store when connecting to the Databroker:
 
 ```shell
 # in repository root
-docker run --rm -it --network kuksa -v ./certificates:/opt/kuksa ghcr.io/eclipse-kuksa/kuksa-databroker-cli:main --server Server:55555 --ca-cert /opt/kuksa/CA.pem
+docker run --rm -it --network kuksa -v ./certificates:/opt/kuksa ghcr.io/eclipse-kuksa/kuksa-databroker-cli:main --server https://Server:55555 --ca-cert /opt/kuksa/CA.pem
 ```
 
 <p align="right">(<a href="#top">back to top</a>)</p>
@@ -264,6 +267,14 @@ Kuksa Databroker implements the following service interfaces:
 - [sdv.databroker.v1.Collector](../proto/sdv/databroker/v1/collector.proto)
 
 <p align="right">(<a href="#top">back to top</a>)</p>
+
+## Troubleshooting
+
+### 'h2 protocol error: http2 error: connection error detected: frame with invalid size'
+
+This error might occur when a client tries to connect to a Databroker with an active TLS configuration while using an 'http://' URL. The URL needs to be changed to 'https://'
+
+The databroker-cli will use 'http://127.0.0.1:55555' as a default value, therefore it is required to specify the `--server` flag (e.g. `--server https://127.0.0.1:55555`) when connecting from databroker-cli.
 
 ## Known Limitations
 

--- a/proto/kuksa/val/v1/val.proto
+++ b/proto/kuksa/val/v1/val.proto
@@ -37,6 +37,8 @@ service VAL {
   // Set entries
   rpc Set(SetRequest) returns (SetResponse);
 
+  rpc StreamedUpdate(stream StreamedUpdateRequest) returns (stream StreamedUpdateResponse);
+
   // Subscribe to a set of entries
   //
   // Returns a stream of notifications.
@@ -84,6 +86,15 @@ message SetRequest {
 // Global errors are specified in `error`.
 // Errors for individual entries are specified in `errors`.
 message SetResponse {
+  Error error                    = 1;
+  repeated DataEntryError errors = 2;
+}
+
+message StreamedUpdateRequest {
+  repeated EntryUpdate updates = 1;
+}
+
+message StreamedUpdateResponse {
   Error error                    = 1;
   repeated DataEntryError errors = 2;
 }


### PR DESCRIPTION
Add support for Streamed Update API. 

I know this is probably not yet in a perfect state, but I still want to trigger the first review. According to the ticket adapting the databroker-cli and databroker-providers is out-of-scope since this is only an intermediate solution and will be shortly overhauled by kuksa val v2 api anyway. I shortly tried to get it to work, but I failed with some weird error messages and incompatible steps. If this is an easy step I am still willing to do it, but I probably need a helping hand to support me there :) 

However, I verified the functionality using 
a) ghz (https://github.com/mikehaller/kuksa-databroker-ghz/tree/main) using the following testcase: 

It sends out 5 requests which 100_000 streamed data points per request
```
{
    "name": "Test Case 5: Kuksa API, StreamedUpdate",
    "proto": "kuksa/val/v1/val.proto",
    "insecure": true,
    "skipFirst": 1,
    "call": "kuksa.val.v1.VAL.StreamedUpdate",
    "total": 6,
    "disable-template-functions": true,
    "disable-template-data": true,
    "stream-call-count": 100000,
    "concurrency": 1,
    "data": {
        "updates": [    
            {
                "entry": {
                    "path": "Vehicle.Speed",
                    "value": {
                        "float": 100.0
                    }
                },
                "fields": [2]
            }
        ]
    }
}
```
using command `ghz --config=testcase105_kuksa_testcase105_kuksa_streamedupdate.json --import-paths=/Users/wba2hi/git/kuksa-databroker/proto localhost:55556 > testcase105_kuksa_streamedupdate.json.output`

and b)
a prototypical implementation in android: https://github.com/boschglobal/kuksa-android-sdk/tree/user/wba2hi/VAL-1320

As an orientation help I used the stream_datapoints api from collector.rs 