### PR TITLE
Check links in documentation as part of build

### DIFF
--- a/.github/workflows/check_license.yml
+++ b/.github/workflows/check_license.yml
@@ -3,7 +3,7 @@ name: Check SPDX headers
 on:
   pull_request:
   workflow_call:
-    
+
 
 concurrency:
       group: ${{ github.ref }}-${{ github.workflow }}
@@ -30,7 +30,7 @@ jobs:
       run: |
         echo "licenses=Apache-2.0" >> $GITHUB_ENV
 
-    - uses: eclipse-kuksa/kuksa-actions/spdx@2
+    - uses: eclipse-kuksa/kuksa-actions/spdx@4
       with:
         files: "${{ env.files }}"
         licenses: "${{ env.licenses }}"

--- a/.github/workflows/kuksa_databroker-cli_build.yml
+++ b/.github/workflows/kuksa_databroker-cli_build.yml
@@ -67,7 +67,7 @@ jobs:
 
   check_ghcr_push:
     name: Check access rights
-    uses: eclipse-kuksa/kuksa-actions/.github/workflows/check_ghcr_push.yml@2
+    uses: eclipse-kuksa/kuksa-actions/.github/workflows/check_ghcr_push.yml@4
     secrets: inherit
 
   build:
@@ -218,7 +218,7 @@ jobs:
         provenance: false
 
     - name: Posting message
-      uses: eclipse-kuksa/kuksa-actions/post-container-location@2
+      uses: eclipse-kuksa/kuksa-actions/post-container-location@4
       with:
         image: ttl.sh/eclipse-kuksa/kuksa-databroker-cli-${{github.sha}}
 

--- a/.github/workflows/kuksa_databroker_build.yml
+++ b/.github/workflows/kuksa_databroker_build.yml
@@ -151,7 +151,7 @@ jobs:
 
   check_ghcr_push:
     name: Check access rights
-    uses: eclipse-kuksa/kuksa-actions/.github/workflows/check_ghcr_push.yml@2
+    uses: eclipse-kuksa/kuksa-actions/.github/workflows/check_ghcr_push.yml@4
     secrets: inherit
 
   create-container:
@@ -251,7 +251,7 @@ jobs:
         provenance: false
 
     - name: Posting message
-      uses: eclipse-kuksa/kuksa-actions/post-container-location@2
+      uses: eclipse-kuksa/kuksa-actions/post-container-location@4
       with:
         image: ttl.sh/eclipse-kuksa/kuksa-databroker-${{github.sha}}
 
@@ -312,3 +312,11 @@ jobs:
         with:
           dashinput: ${{github.workspace}}/dash-databroker-deps
           dashtoken: ${{ secrets.ECLIPSE_GITLAB_API_TOKEN }}
+
+  check-doc-links:
+    name: Check links in markdown
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: eclipse-kuksa/kuksa-actions/check-markdown@4

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <!-- PROJECT LOGO -->
 <br />
 <div align="center">
-  <a href="https://github.com/github_username/repo_name">
+  <a href="https://github.com/eclipse-kuksa/kuksa-databroker">
     <img src="./doc/pictures/logo.png" alt="Logo" width="500px">
   </a>
 
@@ -19,9 +19,9 @@
     <a href="./doc/user_guide.md"><strong>Explore the docs »</strong></a>
     <br />
     <br />
-    <a href="https://github.com/eclipse-kuksa/kuksa-databrokerissues">Report Bug</a>
+    <a href="https://github.com/eclipse-kuksa/kuksa-databroker/issues">Report Bug</a>
     ·
-    <a href="https://github.com/eclipse-kuksa/kuksa-databrokerissues">Request Feature</a>
+    <a href="https://github.com/eclipse-kuksa/kuksa-databroker/issues">Request Feature</a>
     ·
     <a href="https://matrix.to/#/#kuksa-val_community:gitter.im">Chat</a>
   </p>
@@ -32,22 +32,20 @@
   <summary>Table of Contents</summary>
   <ol>
     <li>
-      <a href="#intro">Intro</a>
+      <a href=".#Intro">Intro</a>
       <ul>
         <li><a href="#features">Features</a></li>
-        <li><a href="#built-with">Built With</a></li>
       </ul>
     </li>
     <li>
       <a href="#getting-started">Getting Started</a>
       <ul>
         <li><a href="#prerequisites">Prerequisites</a></li>
-        <li><a href="#installation">Installation</a></li>
-      </ul>
+        <li><a href="#starting-databroker">Starting Databroker</a></li>
+        <li><a href="#reading-and-writing-vss-data-using-the-cli">Reading and writing VSS data using the CLI</a></li>
     </li>
     <li><a href="#usage">Usage</a></li>
     <li><a href="#building">Building</a></li>
-    <li><a href="#roadmap">Roadmap</a></li>
     <li><a href="#contributing">Contributing</a></li>
     <li><a href="#license">License</a></li>
     <li><a href="#contact">Contact</a></li>

--- a/data/vss-core/README.md
+++ b/data/vss-core/README.md
@@ -40,8 +40,8 @@ This is the process for introducing support for a new VSS version:
 * Some files (`*.txt`) instead list all versions, there just add the new version
 * If needed, adapt or extend test cases to use the new version instead of previous version
 * Remember to also integrate new version in [KUKSA Feeder](https://github.com/eclipse/kuksa.val.feeders) repository
-    * Needed for [dbc2val](https://github.com/eclipse/kuksa.val.feeders/blob/main/dbc2val/mapping/mapping.md)
-    * Needed for [dds2val](https://github.com/eclipse/kuksa.val.feeders/blob/main/dds2val/ddsproviderlib/idls/generate_py_dataclass.sh)
+    * Needed for [dbc2val](https://github.com/eclipse-kuksa/kuksa-can-provider/blob/main/mapping/README.md)
+    * Needed for [dds2val](https://github.com/eclipse-kuksa/kuksa-dds-provider/blob/main/ddsproviderlib/idls/generate_py_dataclass.sh)
 
 ### Release Candidate Handling
 
@@ -76,9 +76,9 @@ client> get Vehicle.CurrentLocation.Latitude
 
 ### Kuksa_databroker and dbc2val smoke test
 
-Run dbc2val as described in [documentation](https://github.com/eclipse/kuksa.val.feeders/blob/main/dbc2val/Readme.md) using example [dump file](https://github.com/eclipse/kuksa.val.feeders/blob/main/dbc2val/candump.log). It is important to use databroker mode.
+Run dbc2val as described in [documentation](https://github.com/eclipse-kuksa/kuksa-can-provider/blob/main/README.md) using example [dump file](https://github.com/eclipse-kuksa/kuksa-can-provider/blob/main/candump.log). It is important to use databroker mode.
 
 ```sh
 ./dbcfeeder.py --usecase databroker --address=127.0.0.1:55555
 ```
-Verify that no errors appear in kuksa-val-server log. Not all signals in the [mapping files](https://github.com/eclipse/kuksa.val.feeders/blob/main/dbc2val/mapping) are used by the example dump file, but it can be verified using Kuksa Client that e.g. `Vehicle.Speed` has been given a value.
+Verify that no errors appear in kuksa-val-server log. Not all signals in the [mapping files](https://github.com/eclipse-kuksa/kuksa-can-provider/tree/main/mapping) are used by the example dump file, but it can be verified using Kuksa Client that e.g. `Vehicle.Speed` has been given a value.

--- a/doc/system-architecture.md
+++ b/doc/system-architecture.md
@@ -36,9 +36,9 @@ The following picture shows different kinds of possible KUKSA providers
 
 We assume running a KUKSA VSS server on a vehicle computer. Some signals might originate in an embedded ECU only connected via CAN (e.g. ECU 1). If the Vehicle Computer running the VSS Server has access to the bus, it can run a provider component to map VSS Datapoints.
 
-The [DBC Feeder](https://github.com/eclipse/kuksa.val.feeders/tree/main/dbc2val) is an example of a CAN data-provider. It allows mapping of data from a CAN bus based on a DBC description and some mapping rules.
+The [DBC Feeder](https://github.com/eclipse-kuksa/kuksa-can-provider) is an example of a CAN data-provider. It allows mapping of data from a CAN bus based on a DBC description and some mapping rules.
 
-Other ECUs with Ethernet connectivity might publish data as SOME/IP (ECU 2 in the example) or DDS (ECU 3 in the example) services. The KUKSA project provides an [example SOME/IP provider](https://github.com/eclipse/kuksa.val.feeders/tree/main/someip2val) based on [vsomeip](https://github.com/COVESA/vsomeip) emulating a SOME/IP controllable wiper.
+Other ECUs with Ethernet connectivity might publish data as SOME/IP (ECU 2 in the example) or DDS (ECU 3 in the example) services. The KUKSA project provides an [example SOME/IP provider](https://github.com/eclipse-kuksa/kuksa-someip-provider) based on [vsomeip](https://github.com/COVESA/vsomeip) emulating a SOME/IP controllable wiper.
 
 The Vehicle Computer running the VSS server might run other (automotive) middlewares that provides raw data and signals. In this example we assume the Vehicle Computer runs an AUTOSAR Adaptive subsystem. In that case a provider using the APIs of the underlying system can be created, without the need to parse a specific serialization first. In case of AUTOSAR Adaptive, signals might be accessed using the `ara::com` API.
 

--- a/doc/terminology.md
+++ b/doc/terminology.md
@@ -100,7 +100,7 @@ Attributes are signals that have a default value, specified by its default membe
 The value of a signal. The data type of the value must match the data type specified in the VSS entry for the signal. Currently KUKSA.val supports the _current_value_ for sensors, actuators and attributes as well as _target_value_ for actuators
 
 ## Metadata
-Metadata of a VSS signal is data belonging to a signal, that is not the value. Standard VSS metadata are [unit](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/data_unit_types/) and [datatype](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/data_types/) as well as some human readable description or comments. Custom metadata entries may be defined in [VSS overlays](https://covesa.github.io/vehicle_signal_specification/rule_set/overlay/). Currently KUKSA.val does not support custom metadata.
+Metadata of a VSS signal is data belonging to a signal, that is not the value. Standard VSS metadata are [unit](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/data_units/) and [datatype](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/data_types/) as well as some human readable description or comments. Custom metadata entries may be defined in [VSS overlays](https://covesa.github.io/vehicle_signal_specification/rule_set/overlay/). Currently KUKSA.val does not support custom metadata.
 
 ## Overlay
 VSS has the concept of layering different signal trees on top of each other. This is called [overlay](https://covesa.github.io/vehicle_signal_specification/rule_set/overlay/). A layer may add signals to an existing VSS tree or extending and overriding existing signal entries.

--- a/doc/user_guide.md
+++ b/doc/user_guide.md
@@ -13,7 +13,7 @@ The following sections provide information for running and configuring Databroke
     <li><a href="#getting-help">Getting Help</a></li>
     <li><a href="#running-databroker">Running Databroker</a></li>
     <li><a href="#enabling-authorization">Enabling Authorization</a></li>
-    <li><a href="#enabling-tLS">Enabling TLS</a></li>
+    <li><a href="#enabling-tls">Enabling TLS</a></li>
     <li><a href="#query-syntax">Query Syntax</a></li>
     <li><a href="#using-custom-vss-data-entries">Using Custom VSS Data Entries</a></li>
     <li><a href="#configuration-reference">Configuration Reference</a></li>
@@ -274,7 +274,7 @@ Kuksa Databroker implements the following service interfaces:
 
 This error might occur when a client tries to connect to a Databroker with an active TLS configuration while using an 'http://' URL. The URL needs to be changed to 'https://'
 
-The databroker-cli will use 'http://127.0.0.1:55555' as a default value, therefore it is required to specify the `--server` flag (e.g. `--server https://127.0.0.1:55555`) when connecting from databroker-cli.
+The databroker-cli will use `http://127.0.0.1:55555` as a default value, therefore it is required to specify the `--server` flag (e.g. `--server https://127.0.0.1:55555`) when connecting from databroker-cli.
 
 ## Known Limitations
 


### PR DESCRIPTION
This automates the check link step in https://github.com/eclipse-kuksa/kuksa-databroker/wiki/Release-Process. It will check links on every pull request. Previously we just tested it manually before doing a release.

If this is merged we should update the wiki.



