### PR TITLE
Push databroker container images also to quay.io

### DIFF
--- a/.github/workflows/kuksa_databroker_build.yml
+++ b/.github/workflows/kuksa_databroker_build.yml
@@ -178,6 +178,7 @@ jobs:
         # list of Docker images to use as base name for tags
         images: |
           ghcr.io/eclipse-kuksa/kuksa-databroker
+          quay.io/eclipse-kuksa/kuksa-databroker
         # generate Docker tags based on the following events/attributes
         tags: |
           type=ref,event=branch
@@ -190,13 +191,22 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Log in to the Container registry
+    - name: Log in to ghcr.io container registry
       if: needs.check_ghcr_push.outputs.push == 'true'
       uses: docker/login-action@v3
       with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Log in to quay.io container registry
+      if: needs.check_ghcr_push.outputs.push == 'true'
+      uses: docker/login-action@v3
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_IO_USERNAME }}
+        password: ${{ secrets.QUAY_IO_TOKEN }}
+
 
     - name: Build kuksa-databroker container and push to ghcr.io (and ttl.sh)
       id: ghcr-build


### PR DESCRIPTION
This will push databroker to quay.io. 

Can only really be tested once it is merged, as we can only see then whether the secrets work

See here for background https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/4712

And I did a test with a private quay repo to check the "pattern" used here should work:

https://github.com/SebastianSchildt/testquay
https://github.com/SebastianSchildt/testquay/actions/runs/9386003500/job/25845517800
