### PR TITLE
Make sure quay.io secrets will be transferred when calling databroker build action

### DIFF
--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -53,6 +53,9 @@ jobs:
 
   call_kuksa_databroker_build:
     uses: ./.github/workflows/kuksa_databroker_build.yml
+    secrets:
+      QUAY_IO_TOKEN: ${{ secrets.QUAY_IO_TOKEN }}
+      QUAY_IO_USERNAME: ${{ secrets.QUAY_IO_TOKEN }}
   call_kuksa_databroker-cli_build:
     uses: ./.github/workflows/kuksa_databroker-cli_build.yml
 

--- a/.github/workflows/kuksa_databroker_build.yml
+++ b/.github/workflows/kuksa_databroker_build.yml
@@ -18,6 +18,11 @@ on:
     branches: [ main]
   pull_request:
   workflow_call:
+    secrets:
+      QUAY_IO_TOKEN:
+        required: true
+      QUAY_IO_USERNAME:
+        required: true
   workflow_dispatch:
 
 # suffix to avoid cancellation when running from release workflow
@@ -207,8 +212,7 @@ jobs:
         username: ${{ secrets.QUAY_IO_USERNAME }}
         password: ${{ secrets.QUAY_IO_TOKEN }}
 
-
-    - name: Build kuksa-databroker container and push to ghcr.io (and ttl.sh)
+    - name: Build kuksa-databroker container and push to ghcr.io, quay.io and ttl.sh
       id: ghcr-build
       if: needs.check_ghcr_push.outputs.push == 'true'
       uses: docker/build-push-action@v5


### PR DESCRIPTION
This is required, to make sure quay.io secrets are available when build is called from  draft release workflow