### PR TITLE
Push databroker-cli images also to quay.io

### DIFF
--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -58,6 +58,9 @@ jobs:
       QUAY_IO_USERNAME: ${{ secrets.QUAY_IO_USERNAME }}
   call_kuksa_databroker-cli_build:
     uses: ./.github/workflows/kuksa_databroker-cli_build.yml
+    secrets:
+      QUAY_IO_TOKEN: ${{ secrets.QUAY_IO_TOKEN }}
+      QUAY_IO_USERNAME: ${{ secrets.QUAY_IO_USERNAME }}
 
   create_release:
     runs-on: ubuntu-latest

--- a/.github/workflows/kuksa_databroker-cli_build.yml
+++ b/.github/workflows/kuksa_databroker-cli_build.yml
@@ -24,6 +24,11 @@ on:
       - "Cargo.*"
       - "Cross.toml"
   workflow_call:
+    secrets:
+      QUAY_IO_TOKEN:
+        required: true
+      QUAY_IO_USERNAME:
+        required: true
   workflow_dispatch:
 
 # suffix to avoid cancellation when running from release workflow
@@ -145,6 +150,7 @@ jobs:
         # list of Docker images to use as base name for tags
         images: |
           ghcr.io/eclipse-kuksa/kuksa-databroker-cli
+          quay.io/eclipse-kuksa/kuksa-databroker-cli
         # generate Docker tags based on the following events/attributes
         tags: |
           type=ref,event=branch
@@ -157,7 +163,7 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Log in to the Container registry
+    - name: Log in to ghcr.io container registry
       if: needs.check_ghcr_push.outputs.push == 'true'
       uses: docker/login-action@v3
       with:
@@ -165,7 +171,15 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build kuksa-databroker-cli container and push to ghcr.io (and ttl.sh)
+    - name: Log in to quay.io container registry
+      if: needs.check_ghcr_push.outputs.push == 'true'
+      uses: docker/login-action@v3
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_IO_USERNAME }}
+        password: ${{ secrets.QUAY_IO_TOKEN }}
+
+    - name: Build kuksa-databroker-cli container and push to ghcr.io, quay.io  and ttl.sh
       id: ghcr-build
       if: needs.check_ghcr_push.outputs.push == 'true'
       uses: docker/build-push-action@v5


### PR DESCRIPTION
Does the same for clli ash #39 and #40 did for databroker

@wba2hi  Maybe it makes sense the retag 0.4.5 on final time after this in in, to make sure 
 - we did not mess up (unlikely, I know 😁 
 - Then we have it consistent on quay with 0.4.5 and don't have the situation where databroker is pushed by cli is not

(As per #36  I might still document this in a follow up PR, and also check if there are possibilities to upload older releases, but those are no reasons for blocking or re-tagging a release)