### PR TITLE
Update lib.rs to expose DataEntry and Proto

### DIFF
--- a/lib/kuksa/src/lib.rs
+++ b/lib/kuksa/src/lib.rs
@@ -14,9 +14,9 @@
 use http::Uri;
 use std::collections::HashMap;
 
-use databroker_proto::kuksa::val::{self as proto, v1::DataEntry};
+pub use databroker_proto::kuksa::val::{self as proto, v1::DataEntry};
 
-use kuksa_common::{Client, ClientError};
+pub use kuksa_common::{Client, ClientError};
 
 #[derive(Debug)]
 pub struct KuksaClient {


### PR DESCRIPTION
Hello, this pr aims to make the DataEntry and Proto definition available to allow to extraction of the actual primitive values from object `Vec<DataEntry>` returned by the function .get_current_values();

The public exposure:
`pub use databroker_proto::kuksa::val::{self as proto, v1::DataEntry};`


Thanks to this change, I will be able to correctly parse the DataEntry objects like so:

```
            if let Some(ref _value) = entry.value {
                let speed_as_value = entry.value.and_then(|dp| dp.value);
                match speed_as_value {
                    Some(Float(value)) => {
                        speed = Some(value);
                    }
                    Some(Double(value)) => {
                        speed = Some(value as f32);
                    }
                    _ => {
                        error!("Invalid value type for speed");
                    }
                }
            }
        } else if entry.path == *vss::VSS_VEHICLE_CURRENTLOCATION_LATITUDE {
            if let Some(ref _value) = entry.value {
                let latitude_as_value = entry.value.and_then(|dp| dp.value);
                match latitude_as_value {
                    Some(Float(value)) => {
                        latitude = Some(value as f64);
                    }
                    Some(Double(value)) => {
                        latitude = Some(value);
                    }
                    _ => {
                        error!("Invalid value type for latitude");
                    }
                }
            }
        } else if entry.path == *vss::VSS_VEHICLE_CURRENTLOCATION_LONGITUDE {
            if let Some(ref _value) = entry.value {
                let longitude_as_value = entry.value.and_then(|dp| dp.value);
                match longitude_as_value {
                    Some(Float(value)) => {
                        longitude = Some(value as f64);
                    }
                    Some(Double(value)) => {
                        longitude = Some(value);
                    }
                    _ => {
                        error!("Invalid value type for longitude");
                    }
                }
            }
        }
    }
```

I remain available to assist in case anything would seem unclear!