### PR TITLE
Add get operation for target values

### DIFF
--- a/databroker-cli/src/kuksa_cli.rs
+++ b/databroker-cli/src/kuksa_cli.rs
@@ -265,7 +265,7 @@ pub async fn kuksa_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                                                     .unwrap_or_else(|| "".to_string())
                                             );
                                         } else {
-                                            println!("{}: NotAvailable", entry.path);
+                                            println!("{} is not an actuator.", entry.path);
                                         }
                                     }
                                 }

--- a/databroker/tests/read_write_values.rs
+++ b/databroker/tests/read_write_values.rs
@@ -172,7 +172,7 @@ async fn get_value(w: &mut DataBrokerWorld, value_type: ValueType, path: String)
         .as_mut()
         .expect("no Databroker client available, broker not started?");
     match value_type {
-        ValueType::Target => match client.get_target_values(vec![&path]).await {
+        ValueType::Target => match client.get_target_values(vec![path]).await {
             Ok(res) => w.current_data_entries = Some(res),
             Err(e) => {
                 debug!("failed to invoke Databroker's get operation: {:?}", e);

--- a/lib/kuksa/src/lib.rs
+++ b/lib/kuksa/src/lib.rs
@@ -153,14 +153,14 @@ impl KuksaClient {
 
     pub async fn get_target_values(
         &mut self,
-        paths: Vec<&str>,
+        paths: Vec<String>,
     ) -> Result<Vec<DataEntry>, ClientError> {
         let mut get_result = Vec::new();
 
         for path in paths {
             match self
                 .get(
-                    path,
+                    &path,
                     proto::v1::View::TargetValue,
                     vec![
                         proto::v1::Field::ActuatorTarget.into(),


### PR DESCRIPTION
Adds the ability to get target values for kuksa.val.v1 interface. You can enable by specifying `--protocol kuksa-val-v1`