### PR TITLE
Append release name to create release artifacts.

### DIFF
--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -83,7 +83,12 @@ jobs:
           pattern: databroker*
           merge-multiple: true
       - name: Display structure of downloaded files
-        run: ls -R build-artifacts
+        run: |
+             ls -R build-artifacts
+             cd build-artifacts
+             # Rename, add release name (usually tag)
+             for f in databroker*.tar.gz; do mv "$f" "$(echo "$f" | sed s/.tar.gz/-${{ needs.get_version.outputs.version }}.tar.gz/)"; done
+
 
       - name: Create release
         id: create_release
@@ -91,7 +96,7 @@ jobs:
         # if: startsWith(github.ref, 'refs/tags/'
         with:
           draft: true
-          tag_name: ${{ needs.get_version.outputs.version }}
+          tag_name: KUKSA Databroker ${{ needs.get_version.outputs.version }}
           fail_on_unmatched_files: true
           files: |
             build-artifacts/*


### PR DESCRIPTION
This change adds the release name identifier specified when triggering the draft release workflow.
Also add prefix to created release name (as that was used before)

Old style:

https://github.com/eclipse-kuksa/kuksa-databroker/releases/tag/0.4.6


![image](https://github.com/user-attachments/assets/197d1b5c-1685-4a86-b577-689b768492e3)



New style:

Existing at https://github.com/erikbosch/kuksa-databroker/releases/tag/untagged-ba3e6e0b4a7e7e814be2

![image](https://github.com/user-attachments/assets/968a8bc8-1cb7-4a11-8a37-2334c2cd8415)
