### PR TITLE
Fix regressions

### DIFF
--- a/databroker-cli/src/kuksa_cli.rs
+++ b/databroker-cli/src/kuksa_cli.rs
@@ -312,7 +312,7 @@ pub async fn kuksa_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                                     }
                                 }
                                 Err(err) => {
-                                    cli::print_error(cmd, &format!("Malformed token: {err}"))?
+                                    cli::print_error(cmd, format!("Malformed token: {err}"))?
                                 }
                             }
                         }
@@ -350,12 +350,12 @@ pub async fn kuksa_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                                         }
                                     }
                                     Err(err) => {
-                                        cli::print_error(cmd, &format!("Malformed token: {err}"))?
+                                        cli::print_error(cmd, format!("Malformed token: {err}"))?
                                     }
                                 },
                                 Err(err) => cli::print_error(
                                     cmd,
-                                    &format!(
+                                    format!(
                                         "Failed to open token file \"{token_filename}\": {err}"
                                     ),
                                 )?,

--- a/databroker-cli/src/sdv_cli.rs
+++ b/databroker-cli/src/sdv_cli.rs
@@ -256,7 +256,7 @@ pub async fn sdv_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                                     }
                                 }
                                 Err(err) => {
-                                    cli::print_error(cmd, &format!("Malformed token: {err}"))?
+                                    cli::print_error(cmd, format!("Malformed token: {err}"))?
                                 }
                             }
                         }
@@ -295,12 +295,12 @@ pub async fn sdv_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                                         }
                                     }
                                     Err(err) => {
-                                        cli::print_error(cmd, &format!("Malformed token: {err}"))?
+                                        cli::print_error(cmd, format!("Malformed token: {err}"))?
                                     }
                                 },
                                 Err(err) => cli::print_error(
                                     cmd,
-                                    &format!(
+                                    format!(
                                         "Failed to open token file \"{token_filename}\": {err}"
                                     ),
                                 )?,


### PR DESCRIPTION
`main` is currently failing - see https://github.com/eclipse-kuksa/kuksa-databroker/actions/runs/10921798831

`cargo clippy --fix` shall hopefully fix that.

(Cargo changes format guidelines now and then so regressions are expected)