### PR TITLE
Subscribe by id Integer32 implementation

### DIFF
--- a/databroker/src/broker.rs
+++ b/databroker/src/broker.rs
@@ -200,6 +200,8 @@ pub struct NotificationError {}
 
 #[derive(Debug, Clone, Default)]
 pub struct EntryUpdate {
+    pub id: Option<i32>,
+
     pub path: Option<String>,
 
     pub datapoint: Option<Datapoint>,
@@ -757,6 +759,7 @@ impl ChangeSubscription {
                                             let mut update = EntryUpdate::default();
                                             let mut notify_fields = HashSet::new();
                                             // TODO: Perhaps make path optional
+                                            update.id = Some(entry.metadata.id);
                                             update.path = Some(entry.metadata.path.clone());
                                             if changed_fields.contains(&Field::Datapoint)
                                                 && fields.contains(&Field::Datapoint)
@@ -813,6 +816,7 @@ impl ChangeSubscription {
                                 let mut update = EntryUpdate::default();
                                 let mut notify_fields = HashSet::new();
                                 // TODO: Perhaps make path optional
+                                update.id = Some(entry.metadata.id);
                                 update.path = Some(entry.metadata.path.clone());
                                 if fields.contains(&Field::Datapoint) {
                                     update.datapoint = Some(entry.datapoint.clone());
@@ -2010,6 +2014,7 @@ mod tests {
             .update_entries([(
                 id1,
                 EntryUpdate {
+                    id: Some(id1),
                     path: None,
                     datapoint: Some(Datapoint {
                         ts: time1,
@@ -2042,6 +2047,7 @@ mod tests {
             .update_entries([(
                 id1,
                 EntryUpdate {
+                    id: Some(id1),
                     path: None,
                     datapoint: Some(Datapoint {
                         ts: time1,
@@ -2064,6 +2070,7 @@ mod tests {
             .update_entries([(
                 id2,
                 EntryUpdate {
+                    id: Some(id2),
                     path: None,
                     datapoint: None,
                     actuator_target: Some(Some(Datapoint {
@@ -2136,6 +2143,7 @@ mod tests {
             .update_entries([(
                 id1,
                 EntryUpdate {
+                    id: Some(id1),
                     path: None,
                     datapoint: Some(Datapoint {
                         ts: SystemTime::now(),
@@ -2162,6 +2170,7 @@ mod tests {
             .update_entries([(
                 id1,
                 EntryUpdate {
+                    id: Some(id1),
                     path: None,
                     datapoint: None,
                     actuator_target: None,
@@ -2184,6 +2193,7 @@ mod tests {
             .update_entries([(
                 id1,
                 EntryUpdate {
+                    id: Some(id1),
                     path: None,
                     datapoint: None,
                     actuator_target: None,
@@ -2203,6 +2213,7 @@ mod tests {
             .update_entries([(
                 id1,
                 EntryUpdate {
+                    id: Some(id1),
                     path: None,
                     datapoint: Some(Datapoint {
                         ts: time1,
@@ -2274,6 +2285,7 @@ mod tests {
             .update_entries([(
                 id1,
                 EntryUpdate {
+                    id: Some(id1),
                     path: None,
                     datapoint: Some(Datapoint {
                         ts: SystemTime::now(),
@@ -2376,6 +2388,7 @@ mod tests {
                 .update_entries([(
                     id1,
                     EntryUpdate {
+                        id: Some(id1),
                         path: None,
                         datapoint: Some(Datapoint {
                             ts: SystemTime::now(),
@@ -2459,6 +2472,7 @@ mod tests {
             .update_entries([(
                 id1,
                 EntryUpdate {
+                    id: Some(id1),
                     path: None,
                     datapoint: Some(Datapoint {
                         ts: SystemTime::now(),
@@ -2518,6 +2532,7 @@ mod tests {
             .update_entries([(
                 id1,
                 EntryUpdate {
+                    id: Some(id1),
                     path: None,
                     datapoint: Some(Datapoint {
                         ts: SystemTime::now(),
@@ -2616,6 +2631,7 @@ mod tests {
                     (
                         id1,
                         EntryUpdate {
+                            id: Some(id1),
                             path: None,
                             datapoint: Some(Datapoint {
                                 ts: SystemTime::now(),
@@ -2633,6 +2649,7 @@ mod tests {
                     (
                         id2,
                         EntryUpdate {
+                            id: Some(id2),
                             path: None,
                             datapoint: Some(Datapoint {
                                 ts: SystemTime::now(),
@@ -2696,6 +2713,7 @@ mod tests {
             .update_entries([(
                 id,
                 EntryUpdate {
+                    id: Some(id),
                     path: None,
                     datapoint: Some(Datapoint {
                         ts,
@@ -2761,6 +2779,7 @@ mod tests {
             .update_entries([(
                 id,
                 EntryUpdate {
+                    id: Some(id),
                     path: None,
                     datapoint: Some(Datapoint {
                         ts,
@@ -2841,6 +2860,7 @@ mod tests {
             .update_entries([(
                 id,
                 EntryUpdate {
+                    id: Some(id),
                     path: None,
                     datapoint: Some(Datapoint {
                         ts,
@@ -2897,6 +2917,7 @@ mod tests {
             .update_entries([(
                 id,
                 EntryUpdate {
+                    id: Some(id),
                     path: None,
                     datapoint: Some(Datapoint {
                         ts,
@@ -2952,6 +2973,7 @@ mod tests {
             .update_entries([(
                 id,
                 EntryUpdate {
+                    id: Some(id),
                     path: None,
                     datapoint: Some(Datapoint {
                         ts,
@@ -3004,6 +3026,7 @@ mod tests {
             .update_entries([(
                 id,
                 EntryUpdate {
+                    id: Some(id),
                     path: None,
                     datapoint: Some(Datapoint {
                         ts,
@@ -3033,6 +3056,7 @@ mod tests {
             .update_entries([(
                 id,
                 EntryUpdate {
+                    id: Some(id),
                     path: None,
                     datapoint: Some(Datapoint {
                         ts,
@@ -3090,6 +3114,7 @@ mod tests {
             .update_entries([(
                 id,
                 EntryUpdate {
+                    id: Some(id),
                     path: None,
                     datapoint: Some(Datapoint {
                         ts,
@@ -3119,6 +3144,7 @@ mod tests {
             .update_entries([(
                 id,
                 EntryUpdate {
+                    id: Some(id),
                     path: None,
                     datapoint: Some(Datapoint {
                         ts,
@@ -3179,6 +3205,7 @@ mod tests {
             .update_entries([(
                 id,
                 EntryUpdate {
+                    id: Some(id),
                     path: None,
                     datapoint: Some(Datapoint {
                         ts,
@@ -3266,6 +3293,7 @@ mod tests {
             .update_entries([(
                 id1,
                 EntryUpdate {
+                    id: Some(id1),
                     path: None,
                     datapoint: Some(Datapoint {
                         ts: SystemTime::now(),

--- a/databroker/src/grpc/kuksa_val_v1/val.rs
+++ b/databroker/src/grpc/kuksa_val_v1/val.rs
@@ -977,6 +977,7 @@ impl broker::EntryUpdate {
             None
         };
         Self {
+            id: None,
             path: None,
             datapoint,
             actuator_target,

--- a/databroker/src/grpc/sdv_databroker_v1/broker.rs
+++ b/databroker/src/grpc/sdv_databroker_v1/broker.rs
@@ -122,6 +122,7 @@ impl proto::broker_server::Broker for broker::DataBroker {
                                 ids.push((
                                     metadata.id,
                                     broker::EntryUpdate {
+                                        id: Some(metadata.id),
                                         path: None,
                                         datapoint: None,
                                         actuator_target: Some(Some(broker::Datapoint::from(

--- a/databroker/src/grpc/sdv_databroker_v1/collector.rs
+++ b/databroker/src/grpc/sdv_databroker_v1/collector.rs
@@ -53,6 +53,7 @@ impl proto::collector_server::Collector for broker::DataBroker {
                 (
                     *id,
                     broker::EntryUpdate {
+                        id: Some(*id),
                         path: None,
                         datapoint: Some(broker::Datapoint::from(datapoint)),
                         actuator_target: None,
@@ -122,6 +123,7 @@ impl proto::collector_server::Collector for broker::DataBroker {
                                                 (
                                                     *id,
                                                     broker::EntryUpdate {
+                                                        id: Some(*id),
                                                         path: None,
                                                         datapoint: Some(broker::Datapoint::from(datapoint)),
                                                         actuator_target: None,

--- a/databroker/src/main.rs
+++ b/databroker/src/main.rs
@@ -71,6 +71,7 @@ async fn add_kuksa_attribute(
             let ids = [(
                 id,
                 broker::EntryUpdate {
+                    id: Some(id),
                     datapoint: Some(broker::Datapoint {
                         ts: std::time::SystemTime::now(),
                         source_ts: None,
@@ -133,6 +134,7 @@ async fn read_metadata_file<'a, 'b>(
                     let ids = [(
                         id,
                         broker::EntryUpdate {
+                            id: Some(id),
                             datapoint: Some(broker::Datapoint {
                                 ts: std::time::SystemTime::now(),
                                 source_ts: None,

--- a/databroker/src/viss/v2/server.rs
+++ b/databroker/src/viss/v2/server.rs
@@ -158,6 +158,7 @@ impl Viss for Server {
                 let update = value
                     .try_into_type(&metadata.data_type)
                     .map(|actuator_target| broker::EntryUpdate {
+                        id: None,
                         path: None,
                         datapoint: None,
                         actuator_target: Some(Some(broker::Datapoint {


### PR DESCRIPTION
A variation of the Subscribe method which improves performance by using an Integer32 ID instead of a string for signals parameter.