### PR TITLE
Add reflection support for kuksa.val.v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,6 +631,7 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tonic-mock",
+ "tonic-reflection",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -3138,6 +3139,19 @@ dependencies = [
  "http",
  "http-body",
  "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-reflection"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "548c227bd5c0fae5925812c4ec6c66ffcfced23ea370cb823f4d18f0fc1cb6a7"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tokio",
+ "tokio-stream",
  "tonic",
 ]
 

--- a/databroker-proto/build.rs
+++ b/databroker-proto/build.rs
@@ -11,6 +11,8 @@
 * SPDX-License-Identifier: Apache-2.0
 ********************************************************************************/
 
+use std::{env, path::PathBuf};
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     std::env::set_var("PROTOC", protobuf_src::protoc());
     tonic_build::configure()
@@ -28,5 +30,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             ],
             &["proto"],
         )?;
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    tonic_build::configure()
+        .file_descriptor_set_path(out_dir.join("kuksa.val.v2_descriptor.bin"))
+        .compile(
+            &[
+                "proto/kuksa/val/v2/val.proto",
+                "proto/kuksa/val/v2/types.proto",
+            ],
+            &["proto"],
+        )
+        .unwrap();
+
     Ok(())
 }

--- a/databroker-proto/src/lib.rs
+++ b/databroker-proto/src/lib.rs
@@ -145,6 +145,9 @@ pub mod kuksa {
         }
         pub mod v2 {
             tonic::include_proto!("kuksa.val.v2");
+
+            pub const FILE_DESCRIPTOR_SET: &[u8] =
+                tonic::include_file_descriptor_set!("kuksa.val.v2_descriptor");
         }
     }
 }

--- a/databroker/Cargo.toml
+++ b/databroker/Cargo.toml
@@ -27,6 +27,7 @@ kuksa-common = { path = "../lib/common"}
 kuksa = { path = "../lib/kuksa"}
 databroker-proto = { workspace = true }
 tonic = { workspace = true, features = ["transport", "channel", "prost"] }
+tonic-reflection = "0.11.0"
 prost = { workspace = true }
 prost-types = { workspace = true }
 tokio = { workspace = true, features = [

--- a/databroker/src/grpc/server.rs
+++ b/databroker/src/grpc/server.rs
@@ -189,7 +189,12 @@ where
     let mut router = server.add_optional_service(kuksa_val_v1);
 
     if apis.contains(&Api::KuksaValV2) {
-        router = router.add_optional_service(Some(
+        let service = tonic_reflection::server::Builder::configure()
+            .register_encoded_file_descriptor_set(kuksa::val::v2::FILE_DESCRIPTOR_SET)
+            .build()
+            .unwrap();
+
+        router = router.add_service(service).add_optional_service(Some(
             kuksa::val::v2::val_server::ValServer::with_interceptor(
                 broker.clone(),
                 authorization.clone(),


### PR DESCRIPTION
Release binaries generated locally went from 6.3 MB to 6.5 MB after reflection support was added for kuksa.val.v2

It helps to test kuksa.val.v2 with grpcurl until databroker-cli is updated, i.e:

grpcurl -d '{  "signal_id": { "path": "Vehicle.Speed" },  "data_point": { "timestamp": "2024-10-29T12:04:31.463835877Z", "value": { "float": 75.5 }  }}' -plaintext localhost:55555 kuksa.val.v2.VAL.PublishValue
 
grpcurl -d '{ "signal_id": { "path": "Vehicle.Speed" } }' -plaintext localhost:55555 kuksa.val.v2.VAL.GetValue
 
grpcurl -d '{ "signal_paths": ["Vehicle.Speed"]}' -plaintext localhost:55555 kuksa.val.v2.VAL.Subscribe