### PR TITLE
Improved throughput: reduce unnecessary overload on gRPC bidirectional stream by avoiding empty responses

### DIFF
--- a/databroker-cli/src/sdv_cli.rs
+++ b/databroker-cli/src/sdv_cli.rs
@@ -1262,7 +1262,7 @@ mod test {
                 entry_type: proto::v1::EntryType::Sensor.into(),
                 change_type: proto::v1::ChangeType::OnChange.into(),
                 description: "".into(),
-                value_restriction: None,
+                value_restrictions: None,
             },
             proto::v1::Metadata {
                 id: 2,
@@ -1271,7 +1271,7 @@ mod test {
                 entry_type: proto::v1::EntryType::Sensor.into(),
                 change_type: proto::v1::ChangeType::OnChange.into(),
                 description: "".into(),
-                value_restriction: None,
+                value_restrictions: None,
             },
             proto::v1::Metadata {
                 id: 3,
@@ -1280,7 +1280,7 @@ mod test {
                 entry_type: proto::v1::EntryType::Sensor.into(),
                 change_type: proto::v1::ChangeType::OnChange.into(),
                 description: "".into(),
-                value_restriction: None,
+                value_restrictions: None,
             },
         ]
         .to_vec();

--- a/databroker/src/grpc/kuksa_val_v2/val.rs
+++ b/databroker/src/grpc/kuksa_val_v2/val.rs
@@ -2212,18 +2212,18 @@ mod tests {
                 let entries_size = list_response.metadata.len();
                 assert_eq!(entries_size, 1);
 
-                let value_restriction = Some(proto::ValueRestriction {
-                    r#type: Some(proto::value_restriction::Type::Signed(
-                        proto::ValueRestrictionInt {
-                            allowed_values: Vec::new(),
-                            min: Some(-7),
-                            max: Some(19),
-                        },
-                    )),
+                let value_restrictions = Some(proto::ValueRestrictions {
+                    allowed: None,
+                    min: Some(proto::Value {
+                        typed_value: Some(proto::value::TypedValue::Int64(-7)),
+                    }),
+                    max: Some(proto::Value {
+                        typed_value: Some(proto::value::TypedValue::Int64(19)),
+                    }),
                 });
                 assert_eq!(
-                    list_response.metadata.first().unwrap().value_restriction,
-                    value_restriction
+                    list_response.metadata.first().unwrap().value_restrictions,
+                    value_restrictions
                 )
             }
             Err(_status) => panic!("failed to execute get request"),

--- a/databroker/src/grpc/sdv_databroker_v1/conversions.rs
+++ b/databroker/src/grpc/sdv_databroker_v1/conversions.rs
@@ -303,21 +303,23 @@ impl From<&proto::ChangeType> for broker::ChangeType {
     }
 }
 
-fn value_restriction_from(metadata: &broker::Metadata) -> Option<proto::ValueRestriction> {
+fn value_restriction_from(metadata: &broker::Metadata) -> Option<proto::ValueRestrictions> {
     match metadata.data_type {
         broker::DataType::String | broker::DataType::StringArray => {
             let allowed = match metadata.allowed.as_ref() {
-                Some(broker::DataValue::StringArray(vec)) => vec.clone(),
-                _ => Vec::new(),
+                Some(broker::DataValue::StringArray(vec)) => Some(vec.clone()),
+                _ => None,
             };
 
-            if !allowed.is_empty() {
-                return Some(proto::ValueRestriction {
-                    r#type: Some(proto::value_restriction::Type::String(
-                        proto::ValueRestrictionString {
-                            allowed_values: allowed,
-                        },
-                    )),
+            if allowed.is_some() {
+                return Some(proto::ValueRestrictions {
+                    allowed: allowed.map(|v| proto::Allowed {
+                        values: Some(proto::allowed::Values::StringValues(proto::StringArray {
+                            values: v,
+                        })),
+                    }),
+                    min: None,
+                    max: None,
                 });
             };
         }
@@ -342,23 +344,27 @@ fn value_restriction_from(metadata: &broker::Metadata) -> Option<proto::ValueRes
             let allowed = match metadata.allowed.as_ref() {
                 Some(allowed) => match allowed {
                     broker::DataValue::Int32Array(vec) => {
-                        vec.iter().cloned().map(i64::from).collect()
+                        Some(vec.iter().cloned().map(i64::from).collect())
                     }
-                    broker::DataValue::Int64Array(vec) => vec.to_vec(),
-                    _ => Vec::new(),
+                    broker::DataValue::Int64Array(vec) => Some(vec.to_vec()),
+                    _ => None,
                 },
-                _ => Vec::new(),
+                _ => None,
             };
 
-            if min_value.is_some() | max_value.is_some() | !allowed.is_empty() {
-                return Some(proto::ValueRestriction {
-                    r#type: Some(proto::value_restriction::Type::Signed(
-                        proto::ValueRestrictionInt {
-                            allowed_values: allowed,
-                            min: min_value,
-                            max: max_value,
-                        },
-                    )),
+            if min_value.is_some() | max_value.is_some() | allowed.is_some() {
+                return Some(proto::ValueRestrictions {
+                    allowed: allowed.map(|v| proto::Allowed {
+                        values: Some(proto::allowed::Values::Int64Values(proto::Int64Array {
+                            values: v,
+                        })),
+                    }),
+                    min: min_value.map(|v| proto::ValueRestriction {
+                        typed_value: { Some(proto::value_restriction::TypedValue::Int64(v)) },
+                    }),
+                    max: max_value.map(|v| proto::ValueRestriction {
+                        typed_value: { Some(proto::value_restriction::TypedValue::Int64(v)) },
+                    }),
                 });
             };
         }
@@ -383,23 +389,27 @@ fn value_restriction_from(metadata: &broker::Metadata) -> Option<proto::ValueRes
             let allowed = match metadata.allowed.as_ref() {
                 Some(allowed) => match allowed {
                     broker::DataValue::Uint32Array(vec) => {
-                        vec.iter().cloned().map(u64::from).collect()
+                        Some(vec.iter().cloned().map(u64::from).collect())
                     }
-                    broker::DataValue::Uint64Array(vec) => vec.to_vec(),
-                    _ => Vec::new(),
+                    broker::DataValue::Uint64Array(vec) => Some(vec.to_vec()),
+                    _ => None,
                 },
-                _ => Vec::new(),
+                _ => None,
             };
 
-            if min_value.is_some() | max_value.is_some() | !allowed.is_empty() {
-                return Some(proto::ValueRestriction {
-                    r#type: Some(proto::value_restriction::Type::Unsigned(
-                        proto::ValueRestrictionUint {
-                            allowed_values: allowed,
-                            min: min_value,
-                            max: max_value,
-                        },
-                    )),
+            if min_value.is_some() | max_value.is_some() | allowed.is_some() {
+                return Some(proto::ValueRestrictions {
+                    allowed: allowed.map(|v| proto::Allowed {
+                        values: Some(proto::allowed::Values::Uint64Values(proto::Uint64Array {
+                            values: v,
+                        })),
+                    }),
+                    min: min_value.map(|v| proto::ValueRestriction {
+                        typed_value: { Some(proto::value_restriction::TypedValue::Uint64(v)) },
+                    }),
+                    max: max_value.map(|v| proto::ValueRestriction {
+                        typed_value: { Some(proto::value_restriction::TypedValue::Uint64(v)) },
+                    }),
                 });
             };
         }
@@ -420,23 +430,27 @@ fn value_restriction_from(metadata: &broker::Metadata) -> Option<proto::ValueRes
             let allowed = match metadata.allowed.as_ref() {
                 Some(allowed) => match allowed {
                     broker::DataValue::FloatArray(vec) => {
-                        vec.iter().cloned().map(f64::from).collect()
+                        Some(vec.iter().cloned().map(f64::from).collect())
                     }
-                    broker::DataValue::DoubleArray(vec) => vec.to_vec(),
-                    _ => Vec::new(),
+                    broker::DataValue::DoubleArray(vec) => Some(vec.to_vec()),
+                    _ => None,
                 },
-                _ => Vec::new(),
+                _ => None,
             };
 
-            if min_value.is_some() | max_value.is_some() | !allowed.is_empty() {
-                return Some(proto::ValueRestriction {
-                    r#type: Some(proto::value_restriction::Type::FloatingPoint(
-                        proto::ValueRestrictionFloat {
-                            allowed_values: allowed,
-                            min: min_value,
-                            max: max_value,
-                        },
-                    )),
+            if min_value.is_some() | max_value.is_some() | allowed.is_some() {
+                return Some(proto::ValueRestrictions {
+                    allowed: allowed.map(|v| proto::Allowed {
+                        values: Some(proto::allowed::Values::DoubleValues(proto::DoubleArray {
+                            values: v,
+                        })),
+                    }),
+                    min: min_value.map(|v| proto::ValueRestriction {
+                        typed_value: { Some(proto::value_restriction::TypedValue::Double(v)) },
+                    }),
+                    max: max_value.map(|v| proto::ValueRestriction {
+                        typed_value: { Some(proto::value_restriction::TypedValue::Double(v)) },
+                    }),
                 });
             };
         }
@@ -457,7 +471,7 @@ impl From<&broker::Metadata> for proto::Metadata {
             data_type: proto::DataType::from(&metadata.data_type) as i32,
             change_type: proto::ChangeType::Continuous as i32, // TODO: Add to metadata
             description: metadata.description.to_owned(),
-            value_restriction: value_restriction_from(metadata),
+            value_restrictions: value_restriction_from(metadata),
         }
     }
 }

--- a/proto/kuksa/val/v2/types.proto
+++ b/proto/kuksa/val/v2/types.proto
@@ -12,6 +12,7 @@
  ********************************************************************************/
 
 syntax = "proto3";
+// Please do not add optional fields due to proto3 limitations
 
 package kuksa.val.v2;
 import "google/protobuf/timestamp.proto";
@@ -74,82 +75,58 @@ enum ErrorCode {
 
 message Metadata {
   // ID field
-  int32 id = 10;  // Unique identifier for the metadata entry
+  int32 id                             = 10;
 
   // Data type
   // The VSS data type of the entry (i.e. the value, min, max etc).
   //
   // NOTE: protobuf doesn't have int8, int16, uint8 or uint16 which means
   // that these values must be serialized as int32 and uint32 respectively.
-  DataType data_type                 = 11;  // [field: FIELD_METADATA_DATA_TYPE]
+  DataType data_type                   = 11;
 
   // Entry type
-  EntryType entry_type               = 12;  // [field: FIELD_METADATA_ENTRY_TYPE]
+  EntryType entry_type                 = 12;
 
   // Description
   // Describes the meaning and content of the entry.
-  optional string description        = 13;  // [field: FIELD_METADATA_DESCRIPTION]
+  string description                   = 13;
 
-  // Comment [optional]
+  // Comment
   // A comment can be used to provide additional informal information
   // on a entry.
-  optional string comment            = 14;  // [field: FIELD_METADATA_COMMENT]
+  string comment                       = 14;
 
-  // Deprecation [optional]
+  // Deprecation
   // Whether this entry is deprecated. Can contain recommendations of what
   // to use instead.
-  optional string deprecation        = 15;  // [field: FIELD_METADATA_DEPRECATION]
+  string deprecation                   = 15;
 
-  // Unit [optional]
+  // Unit
   // The unit of measurement
-  optional string unit               = 16;  // [field: FIELD_METADATA_UNIT]
+  string unit                          = 16;
 
-  // Value restrictions [optional]
-  // Restrict which values are allowed.
-  // Only restrictions matching the DataType {datatype} above are valid.
-  ValueRestriction value_restriction = 17;  // [field: FIELD_METADATA_VALUE_RESTRICTION]
+  // Value restrictions checked/enforced by Databroker
+  ValueRestrictions value_restrictions = 17;
 }
 
-// Value restriction
-//
-// One ValueRestriction{type} for each type, since
-// they don't make sense unless the types match
-//
-message ValueRestriction {
-  oneof type {
-    ValueRestrictionString string        = 21;
-    // For signed VSS integers
-    ValueRestrictionInt signed           = 22;
-    // For unsigned VSS integers
-    ValueRestrictionUint unsigned        = 23;
-    // For floating point VSS values (float and double)
-    ValueRestrictionFloat floating_point = 24;
+// Restriction fields are checked/enforced by Databroker.
+// They can be either values specified in VSS, or if not present implicit limits for the datatype.
+message ValueRestrictions {
+  Allowed allowed = 1;
+  Value min       = 2;
+  Value max       = 3;
+}
+
+message Allowed {
+  oneof values {
+    StringArray string_values = 1;
+    Int32Array int32_values   = 3;
+    Int64Array int64_values   = 4;
+    Uint32Array uint32_values = 5;
+    Uint64Array uint64_values = 6;
+    FloatArray float_values   = 7;
+    DoubleArray double_values = 8;
   }
-}
-
-message ValueRestrictionInt {
-  optional sint64 min            = 1;
-  optional sint64 max            = 2;
-  repeated sint64 allowed_values = 3;
-}
-
-message ValueRestrictionUint {
-  optional uint64 min            = 1;
-  optional uint64 max            = 2;
-  repeated uint64 allowed_values = 3;
-}
-
-message ValueRestrictionFloat {
-  optional double min = 1;
-  optional double max = 2;
-
-  // allowed for doubles/floats not recommended
-  repeated double allowed_values = 3;
-}
-
-// min, max doesn't make much sense for a string
-message ValueRestrictionString {
-  repeated string allowed_values = 1;
 }
 
 // VSS Data type of a signal

--- a/proto/kuksa/val/v2/val.proto
+++ b/proto/kuksa/val/v2/val.proto
@@ -12,6 +12,7 @@
  ********************************************************************************/
 
 syntax = "proto3";
+// Please do not add optional fields due to proto3 limitations
 
 package kuksa.val.v2;
 

--- a/proto/sdv/databroker/v1/types.proto
+++ b/proto/sdv/databroker/v1/types.proto
@@ -12,6 +12,7 @@
  ********************************************************************************/
 
 syntax = "proto3";
+// Please do not add optional fields due to proto3 limitations
 
 import "google/protobuf/timestamp.proto";
 
@@ -144,56 +145,54 @@ message Datapoint {
 }
 
 message Metadata {
-  int32 id               = 1;
-  EntryType entry_type   = 2;
-  string name            = 4;
-  DataType data_type     = 5;
-  ChangeType change_type = 6;  // CONTINUOUS or STATIC or ON_CHANGE
-  string description     = 7;
+  int32 id                             = 1;
+  EntryType entry_type                 = 2;
+  string name                          = 4;
+  DataType data_type                   = 5;
+  ChangeType change_type               = 6;  // CONTINUOUS or STATIC or ON_CHANGE
+  string description                   = 7;
 
-  ValueRestriction value_restriction = 10;
-  // int32             min_update_hz       = 10; // Only for CONTINUOUS
-  // int32             max_update_hz       = 11; // Only for CONTINUOUS
+  // Value restrictions checked/enforced by Databroker.
+  ValueRestrictions value_restrictions = 10;
 }
 
-// Value restriction
-//
-// One ValueRestriction{type} for each type, since
-// they don't make sense unless the types match
-//
-message ValueRestriction {
-  oneof type {
-    ValueRestrictionString string        = 21;
-    // For signed VSS integers
-    ValueRestrictionInt signed           = 22;
-    // For unsigned VSS integers
-    ValueRestrictionUint unsigned        = 23;
-    // For floating point VSS values (float and double)
-    ValueRestrictionFloat floating_point = 24;
+// Restriction fields are checked/enforced by Databroker.
+// They can be either values specified in VSS, or if not present implicit limits for the datatype.
+message ValueRestrictions {
+  Allowed allowed      = 1;
+  ValueRestriction min = 2;
+  ValueRestriction max = 3;
+}
+
+message Allowed {
+  oneof values {
+    StringArray string_values = 1;
+    Int32Array int32_values   = 3;
+    Int64Array int64_values   = 4;
+    Uint32Array uint32_values = 5;
+    Uint64Array uint64_values = 6;
+    FloatArray float_values   = 7;
+    DoubleArray double_values = 8;
   }
 }
 
-message ValueRestrictionInt {
-  optional sint64 min            = 1;
-  optional sint64 max            = 2;
-  repeated sint64 allowed_values = 3;
-}
-
-message ValueRestrictionUint {
-  optional uint64 min            = 1;
-  optional uint64 max            = 2;
-  repeated uint64 allowed_values = 3;
-}
-
-message ValueRestrictionFloat {
-  optional double min = 1;
-  optional double max = 2;
-
-  // allowed for doubles/floats not recommended
-  repeated double allowed_values = 3;
-}
-
-// min, max doesn't make much sense for a string
-message ValueRestrictionString {
-  repeated string allowed_values = 1;
+message ValueRestriction {
+  oneof typed_value {
+    string string            = 11;
+    bool bool                = 12;
+    sint32 int32             = 13;
+    sint64 int64             = 14;
+    uint32 uint32            = 15;
+    uint64 uint64            = 16;
+    float float              = 17;
+    double double            = 18;
+    StringArray string_array = 21;
+    BoolArray bool_array     = 22;
+    Int32Array int32_array   = 23;
+    Int64Array int64_array   = 24;
+    Uint32Array uint32_array = 25;
+    Uint64Array uint64_array = 26;
+    FloatArray float_array   = 27;
+    DoubleArray double_array = 28;
+  }
 }


### PR DESCRIPTION
Databroker was underperforming compared to `sdv.databroker.v1` APIs implementation.
gRPC bidirectional stream buffer was being overloaded due to the unnecessary return of empty responses, which caused reduced throughput and buffer congestion.