### PR TITLE
Improved throughput: reduce unnecessary overload on gRPC bidirectional stream by avoiding empty responses

### DIFF
--- a/databroker/src/grpc/kuksa_val_v2/val.rs
+++ b/databroker/src/grpc/kuksa_val_v2/val.rs
@@ -648,7 +648,7 @@ impl proto::val_server::Val for broker::DataBroker {
                                                 let response = publish_values(&broker, &publish_values_request).await;
                                                 if let Some(value) = response {
                                                     if let Err(err) = response_stream_sender.send(Ok(value)).await {
-                                                        debug!("Failed to send response: {}", err);
+                                                        debug!("Failed to send error response: {}", err);
                                                     }
                                                 }
                                             },

--- a/proto/kuksa/val/v2/val.proto
+++ b/proto/kuksa/val/v2/val.proto
@@ -151,7 +151,7 @@ service VAL {
   //          UNAUTHENTICATED if no credentials provided or credentials has expired
   //          ALREADY_EXISTS if a provider already claimed the ownership of an actuator
   //
-  //    - Provider sends PublishValuesRequest -> Databroker returns PublishValuesResponse
+  //    - Provider sends PublishValuesRequest -> Databroker returns PublishValuesResponse upon error, and nothing upon success
   //        GRPC errors are returned as messages in the stream
   //        response with the signal id `map<int32, Error> status = 2;` (permissive case)
   //          NOT_FOUND if a signal is non-existant.


### PR DESCRIPTION
Databroker was underperforming compared to sdv.databroker.v1 APIs implementation.
gRPC bidirectional stream buffer was being overloaded due to the unnecessary return of empty responses, which caused reduced throughput and buffer congestion.

**If we accept this change, Provider will fire and forget since Databroker will not send back any ACK message. Could it overload the gRPC buffer?**