### PR TITLE
Extending BatchActuateStreamResponse

### DIFF
--- a/databroker/src/grpc/kuksa_val_v2/val.rs
+++ b/databroker/src/grpc/kuksa_val_v2/val.rs
@@ -626,8 +626,8 @@ impl proto::val_server::Val for broker::DataBroker {
     //                   e.g. if sending an unsupported enum value
     //              - if the published value is out of the min/max range specified
     //
-    //    - Databroker sends BatchActuateStreamRequest -> Provider may return one or more BatchActuateStreamResponse upon error,
-    //        but should for performance reasons send nothing upon success.
+    //    - Databroker sends BatchActuateStreamRequest -> Provider shall return a BatchActuateStreamResponse,
+    //        for every signal requested to indicate if the request was accepted or not.
     //        It is up to the provider to decide if the stream shall be closed,
     //        as of today Databroker will not react on the received error message.
     //
@@ -683,22 +683,22 @@ impl proto::val_server::Val for broker::DataBroker {
                                             Some(BatchActuateStreamResponse(batch_actuate_stream_response)) => {
 
                                                 if let Some(error) = batch_actuate_stream_response.error {
-                                                    match ErrorCode::try_from(error.code()) {
-                                                        Ok(ErrorCode::Ok)  => {},
+                                                    match error.code() {
+                                                        ErrorCode::Ok  => {},
                                                         _ => {
                                                             let mut msg : String = "Batch actuate stream response error".to_string();
                                                             if let Some(signal_id) = batch_actuate_stream_response.signal_id {
                                                                 match signal_id.signal {
                                                                     Some(proto::signal_id::Signal::Path(path)) => {
-                                                                        msg = msg + ", path: " + &path;
+                                                                        msg = format!("{}, path: {}", msg, &path);
                                                                     }
                                                                     Some(proto::signal_id::Signal::Id(id)) => {
-                                                                        msg = msg + ", id: " + &id.to_string();
+                                                                        msg = format!("{}, id: {}",msg, &id.to_string());
                                                                     }
                                                                     None => {}
                                                                 }
                                                             }
-                                                            msg = msg + ", error code: " + &error.code.to_string() + ", error message: " + &error.message;
+                                                            msg = format!("{}, error code: {}, error message: {}", msg, &error.code.to_string(), &error.message);
                                                             debug!(msg)
                                                         }
                                                     }

--- a/databroker/src/grpc/kuksa_val_v2/val.rs
+++ b/databroker/src/grpc/kuksa_val_v2/val.rs
@@ -32,7 +32,7 @@ use databroker_proto::kuksa::val::v2::{
 
 use kuksa::proto::v2::{
     signal_id, ActuateRequest, ActuateResponse, BatchActuateStreamRequest, ListMetadataResponse,
-    ProvideActuationResponse,
+    ProvideActuationResponse, ErrorCode
 };
 use std::collections::HashSet;
 use tokio::{select, sync::mpsc};
@@ -683,8 +683,8 @@ impl proto::val_server::Val for broker::DataBroker {
                                             Some(BatchActuateStreamResponse(batch_actuate_stream_response)) => {
 
                                                 if let Some(error) = batch_actuate_stream_response.error {
-                                                    match error.code {
-                                                        0 => {},
+                                                    match ErrorCode::try_from(error.code()) {
+                                                        Ok(ErrorCode::Ok)  => {},
                                                         _ => {
                                                             let mut msg : String = "Batch actuate stream response error".to_string();
                                                             if let Some(signal_id) = batch_actuate_stream_response.signal_id {

--- a/databroker/src/grpc/kuksa_val_v2/val.rs
+++ b/databroker/src/grpc/kuksa_val_v2/val.rs
@@ -31,8 +31,8 @@ use databroker_proto::kuksa::val::v2::{
 };
 
 use kuksa::proto::v2::{
-    signal_id, ActuateRequest, ActuateResponse, BatchActuateStreamRequest, ListMetadataResponse,
-    ProvideActuationResponse, ErrorCode
+    signal_id, ActuateRequest, ActuateResponse, BatchActuateStreamRequest, ErrorCode,
+    ListMetadataResponse, ProvideActuationResponse,
 };
 use std::collections::HashSet;
 use tokio::{select, sync::mpsc};

--- a/proto/kuksa/val/v2/types.proto
+++ b/proto/kuksa/val/v2/types.proto
@@ -67,10 +67,11 @@ message Error {
 }
 
 enum ErrorCode {
-  OK                = 0;
-  INVALID_ARGUMENT  = 1;
-  NOT_FOUND         = 2;
-  PERMISSION_DENIED = 3;
+  ERROR_CODE_UNSPECIFIED       = 0; // Default value, never to be explicitly set,
+  ERROR_CODE_OK                = 1;
+  ERROR_CODE_INVALID_ARGUMENT  = 2;
+  ERROR_CODE_NOT_FOUND         = 3;
+  ERROR_CODE_PERMISSION_DENIED = 4;
 }
 
 message Metadata {

--- a/proto/kuksa/val/v2/val.proto
+++ b/proto/kuksa/val/v2/val.proto
@@ -178,8 +178,8 @@ service VAL {
   //                   e.g. if sending an unsupported enum value
   //              - if the published value is out of the min/max range specified
   //
-  //    - Databroker sends BatchActuateStreamRequest -> Provider may return one or more BatchActuateStreamResponse upon error,
-  //        but should for performance reasons send nothing upon success.
+  //    - Databroker sends BatchActuateStreamRequest -> Provider shall return a BatchActuateStreamResponse,
+  //        for every signal requested to indicate if the request was accepted or not.
   //        It is up to the provider to decide if the stream shall be closed,
   //        as of today Databroker will not react on the received error message.
   //
@@ -282,9 +282,7 @@ message BatchActuateStreamRequest {
   repeated ActuateRequest actuate_requests = 1;
 }
 
-// Message that can be used by provider to indicate that an actuation request was not accepted.
-// It is optional for the provider to use this message, and for performance reasons it is recommended
-// not to send it upon success.
+// Message that shall be used by provider to indicate if an actuation request was accepted.
 message BatchActuateStreamResponse {
   SignalID signal_id   = 1;
   Error error = 2;

--- a/proto/kuksa/val/v2/val.proto
+++ b/proto/kuksa/val/v2/val.proto
@@ -178,8 +178,10 @@ service VAL {
   //                   e.g. if sending an unsupported enum value
   //              - if the published value is out of the min/max range specified
   //
-  //    - Provider returns BatchActuateStreamResponse <- Databroker sends BatchActuateStreamRequest
-  //        No error definition, a BatchActuateStreamResponse is expected from provider.
+  //    - Databroker sends BatchActuateStreamRequest -> Provider may return one or more BatchActuateStreamResponse upon error,
+  //        but should for performance reasons send nothing upon success.
+  //        It is up to the provider to decide if the stream shall be closed,
+  //        as of today Databroker will not react on the received error message.
   //
   rpc OpenProviderStream(stream OpenProviderStreamRequest) returns (stream OpenProviderStreamResponse);
 
@@ -280,7 +282,12 @@ message BatchActuateStreamRequest {
   repeated ActuateRequest actuate_requests = 1;
 }
 
+// Message that can be used by provider to indicate that an actuation request was not accepted.
+// It is optional for the provider to use this message, and for performance reasons it is recommended
+// not to send it upon success.
 message BatchActuateStreamResponse {
+  SignalID signal_id   = 1;
+  Error error = 2;
 }
 
 message OpenProviderStreamRequest {


### PR DESCRIPTION
This PR is based on analysis of `OpenProviderStream` at https://github.com/eclipse-kuksa/kuksa-databroker/blob/main/proto/kuksa/val/v2/val.proto#L184. One identified gap is if the provider by some reason does not like the actuate request received from Databroker. As of today the only counter measure it can do is to close the stream.

This PR propose to extend `BatchActuateStreamResponse` so that the provider can send error messages back to databroker. It can send as many `BatchActuateStreamResponse` as it likes. 

It reuses

```
enum ErrorCode {
  OK                = 0;
  INVALID_ARGUMENT  = 1;
  NOT_FOUND         = 2;
  PERMISSION_DENIED = 3;
}
```

A hypothetical use case is the the provider by some reason has a different accepted value range for a signal. Then it could return `INVALID_ARGUMENT `. Databroker will as of today just print this info on debug level, but it could help for troubleshooting. The provider may in addition decide to close the stream, if it thinks the error is so severe that it do not want to talk to Databroker any longer. A hypothetical example could be if the Provider assumes that the Databroker is compromised or has a misconfiguration. 


