### PR TITLE
Accept 0 as buffer size

### DIFF
--- a/databroker/src/broker.rs
+++ b/databroker/src/broker.rs
@@ -1642,8 +1642,10 @@ impl<'a, 'b> AuthorizedAccess<'a, 'b> {
             if cap > MAX_SUBSCRIBE_BUFFER_SIZE {
                 return Err(SubscriptionError::InvalidBufferSize);
             }
-            cap
+            // Requested capacity for old messages plus 1 for latest
+            cap + 1
         } else {
+            // Just latest message
             1
         };
 

--- a/databroker/src/grpc/kuksa_val_v1/val.rs
+++ b/databroker/src/grpc/kuksa_val_v1/val.rs
@@ -600,7 +600,7 @@ impl proto::val_server::Val for broker::DataBroker {
             }
         }
 
-        match broker.subscribe(entries, Some(1)).await {
+        match broker.subscribe(entries, None).await {
             Ok(stream) => {
                 let stream = convert_to_proto_stream(stream);
                 Ok(tonic::Response::new(Box::pin(stream)))

--- a/databroker/src/grpc/kuksa_val_v2/val.rs
+++ b/databroker/src/grpc/kuksa_val_v2/val.rs
@@ -222,12 +222,6 @@ impl proto::val_server::Val for broker::DataBroker {
         };
 
         let request = request.into_inner();
-        if request.buffer_size == 0 {
-            return Err(tonic::Status::invalid_argument(format!(
-                "Provided buffer_size {} should be greater than zero.",
-                request.buffer_size
-            )));
-        }
 
         let broker = self.authorized_access(&permissions);
 
@@ -301,12 +295,6 @@ impl proto::val_server::Val for broker::DataBroker {
         };
 
         let request = request.into_inner();
-        if request.buffer_size == 0 {
-            return Err(tonic::Status::invalid_argument(format!(
-                "Provided lag_buffer_capacity {} should be greater than zero.",
-                request.buffer_size
-            )));
-        }
 
         let broker = self.authorized_access(&permissions);
 

--- a/databroker/src/viss/v2/server.rs
+++ b/databroker/src/viss/v2/server.rs
@@ -271,7 +271,7 @@ impl Viss for Server {
             });
         };
 
-        match broker.subscribe(entries, Some(1)).await {
+        match broker.subscribe(entries, None).await {
             Ok(stream) => {
                 let subscription_id = SubscriptionId::new();
 

--- a/proto/kuksa/val/v2/val.proto
+++ b/proto/kuksa/val/v2/val.proto
@@ -208,6 +208,8 @@ message SubscribeRequest {
 
   // Specifies the number of messages that can be buffered for
   // slow subscribers before the oldest messages are dropped.
+  // Default (0) results in that only latest message is kept.
+  // Maximum value supported is implementation dependent.
   uint32 buffer_size           = 2;
 }
 
@@ -220,6 +222,8 @@ message SubscribeByIdRequest {
 
   // Specifies the number of messages that can be buffered for
   // slow subscribers before the oldest messages are dropped.
+  // Default (0) results in that only latest message is kept.
+  // Maximum value supported is implementation dependent.
   uint32 buffer_size        = 2;
 }
 


### PR DESCRIPTION
I noticed that we did not support the implicit default value 0 for `buffer_size`, i.e. any user would need to specify buffer size, and I do not really see that as something that provide any extra value, so proposing a change in behavior.

- Make 0 an allowed value
- Change the meaning so that `buffer_size` indicates number of "slots" for older messages, i.e. if you specify `1` you will actually use `2 ` in code.

With this change the code can be simplified, as we do not need the special check for `buffer_size==0`. 