### PR TITLE
Changing ListMetaData to correspond to reality

### DIFF
--- a/proto/kuksa/val/v2/val.proto
+++ b/proto/kuksa/val/v2/val.proto
@@ -128,7 +128,7 @@ service VAL {
   // List metadata of signals matching the request.
   //
   // Returns (GRPC error code):
-  //   NOT_FOUND if the specified root branch does not exist.
+  //   NOT_FOUND if no signals matching the request are found.
   //   UNAUTHENTICATED if no credentials provided or credentials has expired
   //   INVALID_ARGUMENT if the provided path or wildcard is wrong.
   //
@@ -247,8 +247,9 @@ message BatchActuateResponse {
 }
 
 message ListMetadataRequest {
-  string root   = 1;
-  string filter = 2;
+  // A path which may include wildcards
+  // See https://github.com/eclipse-kuksa/kuksa-databroker/blob/main/doc/wildcard_matching.md
+  string path   = 1;
 }
 
 message ListMetadataResponse {


### PR DESCRIPTION
We do not use the `filter` field, and the name `root` is not that logical. In older API supporting same wildcard syntax we use the term `path`, so proposing to change to that.

https://github.com/eclipse-kuksa/kuksa-databroker/blob/main/proto/kuksa/val/v1/val.proto#L104

```
message SubscribeEntry {
  string path           = 1;
  View view             = 2;
  repeated Field fields = 3;
}
```

Related to discussion at https://github.com/eclipse-kuksa/kuksa-databroker/pull/105/files#r1848167147