### PR TITLE
Rename datapoints

### DIFF
--- a/databroker/src/grpc/kuksa_val_v2/val.rs
+++ b/databroker/src/grpc/kuksa_val_v2/val.rs
@@ -809,7 +809,7 @@ async fn publish_values(
     request: &databroker_proto::kuksa::val::v2::PublishValuesRequest,
 ) -> Option<OpenProviderStreamResponse> {
     let ids: Vec<(i32, broker::EntryUpdate)> = request
-        .datapoints
+        .data_points
         .iter()
         .map(|(id, datapoint)| {
             (
@@ -2132,7 +2132,7 @@ mod tests {
             action: Some(open_provider_stream_request::Action::PublishValuesRequest(
                 PublishValuesRequest {
                     request_id,
-                    datapoints: {
+                    data_points: {
                         let timestamp = Some(std::time::SystemTime::now().into());
 
                         let value = proto::Value {

--- a/proto/kuksa/val/v2/val.proto
+++ b/proto/kuksa/val/v2/val.proto
@@ -267,7 +267,7 @@ message PublishValueResponse {
 
 message PublishValuesRequest {
   int32 request_id                 = 1; /// Unique request id for the stream that can be used to identify the response.
-  map<int32, Datapoint> datapoints = 2;
+  map<int32, Datapoint> data_points = 2;
 }
 
 message PublishValuesResponse {


### PR DESCRIPTION
Based on a comment at https://github.com/eclipse-kuksa/kuksa-databroker/pull/106#discussion_r1853649367 from @BjoernAtBosch 

Should we possibly use `data_points` instead of `datapoints`. Most other members in v2 use the form `data_point` / `data_points`

If we are to change it, maybe it is good to change it now.