### PR TITLE
Update version to 0.6.0-dev.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "databroker"
-version = "0.5.0"
+version = "0.6.0-dev.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "databroker-cli"
-version = "0.5.0"
+version = "0.6.0-dev.0"
 dependencies = [
  "ansi_term",
  "clap",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "databroker-proto"
-version = "0.5.0"
+version = "0.6.0-dev.0"
 dependencies = [
  "prost",
  "prost-types",
@@ -1890,9 +1890,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "540654e97a3f4470a492cd30ff187bc95d89557a903a2bbf112e2fae98104ef2"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jemalloc-sys"
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "kuksa"
-version = "0.5.0"
+version = "0.6.0-dev.0"
 dependencies = [
  "databroker-proto",
  "http",
@@ -1952,7 +1952,7 @@ dependencies = [
 
 [[package]]
 name = "kuksa-common"
-version = "0.5.0"
+version = "0.6.0-dev.0"
 dependencies = [
  "databroker-proto",
  "http",
@@ -1963,7 +1963,7 @@ dependencies = [
 
 [[package]]
 name = "kuksa-sdv"
-version = "0.5.0"
+version = "0.6.0-dev.0"
 dependencies = [
  "databroker-proto",
  "http",
@@ -2004,9 +2004,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.164"
+version = "0.2.165"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
+checksum = "fcb4d3d38eab6c5239a362fa8bae48c03baf980a6e7079f063942d563ef3533e"
 
 [[package]]
 name = "libredox"
@@ -3405,9 +3405,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
 ]

--- a/databroker-cli/Cargo.toml
+++ b/databroker-cli/Cargo.toml
@@ -13,7 +13,7 @@
 
 [package]
 name = "databroker-cli"
-version = "0.5.0"
+version = "0.6.0-dev.0"
 authors = ["Eclipse KUKSA Project"]
 edition = "2021"
 license = "Apache-2.0"

--- a/databroker-proto/Cargo.toml
+++ b/databroker-proto/Cargo.toml
@@ -13,7 +13,7 @@
 
 [package]
 name = "databroker-proto"
-version = "0.5.0"
+version = "0.6.0-dev.0"
 authors = ["Eclipse KUKSA Project"]
 edition = "2021"
 license = "Apache-2.0"

--- a/databroker/Cargo.toml
+++ b/databroker/Cargo.toml
@@ -13,7 +13,7 @@
 
 [package]
 name = "databroker"
-version = "0.5.0"
+version = "0.6.0-dev.0"
 authors = ["Eclipse KUKSA Project"]
 edition = "2021"
 license = "Apache-2.0"

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -187,7 +187,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "databroker-proto"
-version = "0.5.0"
+version = "0.6.0-dev.0"
 dependencies = [
  "prost",
  "prost-types",
@@ -436,13 +436,13 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "540654e97a3f4470a492cd30ff187bc95d89557a903a2bbf112e2fae98104ef2"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "kuksa"
-version = "0.5.0"
+version = "0.6.0-dev.0"
 dependencies = [
  "databroker-proto",
  "http",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "kuksa-common"
-version = "0.5.0"
+version = "0.6.0-dev.0"
 dependencies = [
  "databroker-proto",
  "http",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "kuksa-sdv"
-version = "0.5.0"
+version = "0.6.0-dev.0"
 dependencies = [
  "databroker-proto",
  "http",
@@ -477,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.164"
+version = "0.2.165"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
+checksum = "fcb4d3d38eab6c5239a362fa8bae48c03baf980a6e7079f063942d563ef3533e"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1098,9 +1098,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
 ]

--- a/lib/common/Cargo.toml
+++ b/lib/common/Cargo.toml
@@ -13,7 +13,7 @@
 
 [package]
 name = "kuksa-common"
-version = "0.5.0"
+version = "0.6.0-dev.0"
 authors = ["Eclipse KUKSA Project"]
 edition = "2021"
 license = "Apache-2.0"

--- a/lib/kuksa/Cargo.toml
+++ b/lib/kuksa/Cargo.toml
@@ -13,7 +13,7 @@
 
 [package]
 name = "kuksa"
-version = "0.5.0"
+version = "0.6.0-dev.0"
 authors = ["Eclipse KUKSA Project"]
 edition = "2021"
 license = "Apache-2.0"

--- a/lib/sdv/Cargo.toml
+++ b/lib/sdv/Cargo.toml
@@ -13,7 +13,7 @@
 
 [package]
 name = "kuksa-sdv"
-version = "0.5.0"
+version = "0.6.0-dev.0"
 authors = ["Eclipse KUKSA Project"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
Performed by `scripts/prepare_release.sh 0.6.0-dev.0`. This is to make sure that if someone builds from source it should be clearly visible that they are not using the official 0.5.0 version.