### PR TITLE
Change release flow

### DIFF
--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -14,17 +14,11 @@
 name: Create Draft Release
 
 on:
-  workflow_dispatch: # input version manually. Overrides push tag
-    inputs:
-      tag:
-        description: "Release version, eg:latest, 0.2.1"
-        required: true
-        default: "0.0.0"
+  workflow_dispatch: # select tag when creating
+  push:
+   tags:
+     - "*.*.*"
 
-  # As of today trigger only manually
-  #push:
-  #  tags:
-  #    - "*.*.*"
 
 # Needed if GITHUB_TOKEN by default do not have right to create release
 permissions:
@@ -87,8 +81,7 @@ jobs:
              ls -R build-artifacts
              cd build-artifacts
              # Rename, add release name (usually tag)
-             for f in databroker*.tar.gz; do mv "$f" "$(echo "$f" | sed s/.tar.gz/-${{ needs.get_version.outputs.version }}.tar.gz/)"; done
-
+             for f in databroker*.tar.gz; do mv "$f" "$(echo "$f" | sed s/.tar.gz/-${{ github.ref_name }}.tar.gz/)"; done
 
       - name: Create release
         id: create_release
@@ -96,7 +89,7 @@ jobs:
         # if: startsWith(github.ref, 'refs/tags/'
         with:
           draft: true
-          tag_name: KUKSA Databroker ${{ needs.get_version.outputs.version }}
+          name: KUKSA Databroker ${{ github.ref_name }}
           fail_on_unmatched_files: true
           files: |
             build-artifacts/*

--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -14,11 +14,9 @@
 name: Create Draft Release
 
 on:
-  workflow_dispatch: # select tag when creating
   push:
    tags:
      - "*.*.*"
-
 
 # Needed if GITHUB_TOKEN by default do not have right to create release
 permissions:

--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -24,25 +24,6 @@ permissions:
   packages: write
 
 jobs:
-  get_version:
-    runs-on: ubuntu-latest
-    # Map a step output to a job output
-    outputs:
-      version: ${{ steps.eval_version.outputs.version }}
-    steps:
-      - name: Get tag or user release version
-        id: eval_version
-        run: |
-          GIT_VER="${GITHUB_REF/refs\/tags\//}"
-          echo "### Detected tag: $GIT_VER"
-          if [ -n "${{ github.event.inputs.tag }}" ]; then
-            GIT_VER="${{ github.event.inputs.tag }}"
-            echo "Forced release version: $GIT_VER"
-            echo "version=${GIT_VER}" >> $GITHUB_OUTPUT
-          else
-            echo "version=${GIT_VER}" >> $GITHUB_OUTPUT
-          fi
-
   call_kuksa_databroker_build:
     uses: ./.github/workflows/kuksa_databroker_build.yml
     secrets:
@@ -58,7 +39,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       [
-        get_version,
         call_kuksa_databroker_build,
         call_kuksa_databroker-cli_build,
       ]


### PR DESCRIPTION
This is a proposal to change the release handling somewhat

# Today 

* Create a tag and push to remote
* Trigger workflow on the tag and mention wanted version (e.g. `1.2.3`)

*If you trigger on branch you will get a faulty tag proposal in draft release that you must correct, tag will be created when release is published*

# After this PR

* Create a tag and push to remote
* Creation of release is started automatically

*If you run the workflow on a branch you will get a release named after the branch, which you likely do not want*