### PR TITLE
Fix no-tls build for databroker

### DIFF
--- a/databroker-cli/Cargo.toml
+++ b/databroker-cli/Cargo.toml
@@ -48,4 +48,4 @@ http = "0.2.8"
 
 [features]
 default = ["tls"]
-tls = ["tonic/tls"]
+tls = ["tonic/tls", "kuksa-common/tls", "kuksa/tls"]

--- a/databroker/Cargo.toml
+++ b/databroker/Cargo.toml
@@ -74,7 +74,7 @@ sd-notify = "0.4.1"
 
 [features]
 default = ["tls"]
-tls = ["tonic/tls"]
+tls = ["tonic/tls", "kuksa-common/tls", "kuksa/tls"]
 jemalloc = ["dep:jemallocator"]
 viss = ["dep:axum", "dep:chrono", "dep:uuid"]
 libtest = []

--- a/databroker/src/grpc/server.rs
+++ b/databroker/src/grpc/server.rs
@@ -156,6 +156,7 @@ where
     serve_with_incoming_shutdown(
         incoming,
         broker,
+        #[cfg(feature = "tls")]
         ServerTLS::Disabled,
         apis,
         authorization,

--- a/databroker/src/main.rs
+++ b/databroker/src/main.rs
@@ -27,14 +27,11 @@ use databroker::broker::RegistrationError;
 #[cfg(feature = "tls")]
 use databroker::grpc::server::ServerTLS;
 
+use clap::{Arg, ArgAction, Command};
 use std::thread::available_parallelism;
 use tokio::select;
 use tokio::signal::unix::{signal, SignalKind};
-#[cfg(feature = "tls")]
-use tracing::warn;
-use tracing::{debug, error, info};
-
-use clap::{Arg, ArgAction, Command};
+use tracing::{debug, error, info, warn};
 
 #[cfg(feature = "viss")]
 use databroker::viss;

--- a/lib/common/Cargo.toml
+++ b/lib/common/Cargo.toml
@@ -33,5 +33,4 @@ crate-type = ["lib"]
 path = "src/lib.rs"
 
 [features]
-default = ["tls"]
 tls = ["tonic/tls"]

--- a/lib/kuksa/Cargo.toml
+++ b/lib/kuksa/Cargo.toml
@@ -34,5 +34,4 @@ crate-type = ["lib"]
 path = "src/lib.rs"
 
 [features]
-default = ["tls"]
 tls = ["tonic/tls"]


### PR DESCRIPTION
This PR fixes the broken build when building `kuksa-databroker` with `--no-default-features` flag.
Additionally i have also enforced that `tls` feature flag for `kuksa` and `common` are not used in `no-default-feature` mode.