### PR TITLE
Initial example for testing slow subscribers

### DIFF
--- a/databroker/src/broker.rs
+++ b/databroker/src/broker.rs
@@ -1670,10 +1670,10 @@ impl<'a, 'b> AuthorizedAccess<'a, 'b> {
             .await
             .add_change_subscription(subscription);
 
-        let stream = BroadcastStream::new(receiver).filter_map(|result| match result {
+        let stream = BroadcastStream::new(receiver).filter_map(move |result| match result {
             Ok(message) => Some(message),
             Err(err) => {
-                debug!("Lagged entries: {}", err);
+                warn!("Slow subscriber with capacity {} lagged and missed signal updates: {}", channel_capacity, err);
                 None
             }
         });

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -186,6 +186,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "databroker-examples"
+version = "0.1.0"
+dependencies = [
+ "kuksa",
+ "kuksa-common",
+ "kuksa-sdv",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "databroker-proto"
 version = "0.6.0-dev.0"
 dependencies = [
@@ -488,6 +499,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,6 +573,29 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -731,6 +775,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,6 +893,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "serde"
 version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +925,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,6 +941,12 @@ checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
@@ -936,7 +1010,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -4,7 +4,8 @@ resolver = "2"
 members = [
     "common",
     "kuksa",
-    "sdv"
+    "sdv",
+    "databroker-examples"
 ]
 
 [workspace.dependencies]

--- a/lib/databroker-examples/Cargo.toml
+++ b/lib/databroker-examples/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "databroker-examples"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+kuksa-common = { path = "../common"}
+kuksa = { path = "../kuksa"}
+kuksa-sdv = { path = "../sdv"}
+tokio = {version = "1.17.0", features = ["full"]}
+tokio-stream = "0.1.8"

--- a/lib/databroker-examples/examples/slow_subscriber.rs
+++ b/lib/databroker-examples/examples/slow_subscriber.rs
@@ -1,0 +1,49 @@
+/********************************************************************************
+* Copyright (c) 2024 Contributors to the Eclipse Foundation
+*
+* See the NOTICE file(s) distributed with this work for additional
+* information regarding copyright ownership.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Apache License 2.0 which is available at
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* SPDX-License-Identifier: Apache-2.0
+********************************************************************************/
+
+use kuksa::KuksaClient;
+use tokio::time::{sleep, Duration};
+use kuksa_common::to_uri;
+use std::thread;
+
+#[tokio::main]
+async fn main() {
+
+    // Paths to subscribe
+    let paths = vec!["Vehicle.Speed"];
+
+    // Initialize the KuksaClient
+    let mut client: KuksaClient = KuksaClient::new(to_uri("127.0.0.1:55555").unwrap());
+
+    // Subscribe to paths
+    let mut stream = client.subscribe(paths.clone()).await.unwrap();
+
+    println!("Subscribed to {:?}", paths);
+
+    loop {
+        match stream.message().await {
+            Ok(msg) => {
+                println!("Got message, will wait 5 seconds: {:?}", msg);
+                // Simulate slow processing by sleeping
+                sleep(Duration::from_secs(1)).await;
+                thread::sleep(Duration::from_secs(5));
+            }
+            Err(e) => {
+                println!("Error while receiving message: {:?}", e);
+                break; // Exit loop on error
+            }
+        }
+    }
+
+    println!("Exiting subscriber...");
+}


### PR DESCRIPTION
The example shows a subscriber which is intentionally slow in receiving updates.

When running in parallel with kuksa-perf, there are too many updates of the signal which the slow subscriber will not be able to keep up with and will start throwing away signal updates. When this happens, the channel on the databroker side will log a warning message and indicate how many signal updates were lost for the slow subscriber.