### PR TITLE
Upload test results to codecov

### DIFF
--- a/.github/workflows/kuksa_databroker_build.yml
+++ b/.github/workflows/kuksa_databroker_build.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate test results
-        cargo test --all-features --junitxml=test_results.xml
+        run: cargo test --all-features --junitxml=test_results.xml
       - name: Generate code coverage
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info --summary | tee test_summary.log
       - name: Upload coverage to Codecov

--- a/.github/workflows/kuksa_databroker_build.yml
+++ b/.github/workflows/kuksa_databroker_build.yml
@@ -122,8 +122,10 @@ jobs:
           key: databroker-coverage-${{ hashFiles('**/Cargo.lock') }}
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Install cargo-junit
+        run: cargo install cargo-junit
       - name: Generate test results
-        run: cargo test --all-features --junitxml=test_results.xml
+        run: cargo junit --all-features --name test_results.xml
       - name: Generate code coverage
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info --summary | tee test_summary.log
       - name: Upload coverage to Codecov

--- a/.github/workflows/kuksa_databroker_build.yml
+++ b/.github/workflows/kuksa_databroker_build.yml
@@ -130,7 +130,7 @@ jobs:
           features=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "databroker") | .features | keys | .[]' | tr '\n' ' ')
           echo "features=$features" >> $GITHUB_ENV
       - name: Generate test results
-        run: cargo junit --features "$features" libtest --name test_results.xml
+        run: cargo junit --features "$features" --name test_results.xml
       - name: Generate code coverage
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info --summary | tee test_summary.log
       - name: Upload coverage to Codecov

--- a/.github/workflows/kuksa_databroker_build.yml
+++ b/.github/workflows/kuksa_databroker_build.yml
@@ -133,10 +133,10 @@ jobs:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload test results to Codecov
-      	if: ${{ !cancelled() }}
+        if: ${{ !cancelled() }}
         uses: codecov/test-results-action@v1
         with:
-        files: test_results.xml
+          files: test_results.xml
           token: ${{ secrets.CODECOV_TOKEN }}
       - uses: taiki-e/install-action@v2.9.4
         with:
@@ -327,7 +327,7 @@ jobs:
         run: |
           ${{github.workspace}}/integration_test/run.sh
       - name: Upload test results to Codecov
-      	if: ${{ !cancelled() }}
+        if: ${{ !cancelled() }}
         uses: codecov/test-results-action@v1
         with:
           files: pytest_results.xml

--- a/.github/workflows/kuksa_databroker_build.yml
+++ b/.github/workflows/kuksa_databroker_build.yml
@@ -124,8 +124,13 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Install cargo-junit
         run: cargo install cargo-junit
+      - name: Get features for databroker
+        id: get_features
+        run: |
+          features=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "databroker") | .features | keys | .[]' | tr '\n' ' ')
+          echo "features=$features" >> $GITHUB_ENV
       - name: Generate test results
-        run: cargo junit --all-features --name test_results.xml
+        run: cargo junit --features "$features" libtest --name test_results.xml
       - name: Generate code coverage
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info --summary | tee test_summary.log
       - name: Upload coverage to Codecov

--- a/.github/workflows/kuksa_databroker_build.yml
+++ b/.github/workflows/kuksa_databroker_build.yml
@@ -122,13 +122,21 @@ jobs:
           key: databroker-coverage-${{ hashFiles('**/Cargo.lock') }}
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate test results
+        cargo test --all-features --junitxml=test_results.xml
       - name: Generate code coverage
-        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info --summary | tee test_summary.log
       - name: Upload coverage to Codecov
         # Uploaded result available at https://app.codecov.io/gh/eclipse-kuksa/kuksa-databroker
         uses: codecov/codecov-action@v4
         with:
           files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload test results to Codecov
+      	if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+        files: test_results.xml
           token: ${{ secrets.CODECOV_TOKEN }}
       - uses: taiki-e/install-action@v2.9.4
         with:
@@ -318,6 +326,12 @@ jobs:
           CONTAINER_PLATFORM: linux/${{ matrix.platform }}
         run: |
           ${{github.workspace}}/integration_test/run.sh
+      - name: Upload test results to Codecov
+      	if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          files: pytest_results.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   bom:
     name: License Compliance Check

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -31,7 +31,7 @@ RUNNING_IMAGE=$(
     docker run -d -v ${VSS_DATA_DIR}:/data -p 55555:55555 --rm  --platform ${CONTAINER_PLATFORM} ${DATABROKER_IMAGE} --metadata data/vss-core/vss_release_4.0.json --insecure --enable-databroker-v1
 )
 
-python3 -m pytest -v "${SCRIPT_DIR}/test_databroker.py"
+python3 -m pytest -v "${SCRIPT_DIR}/test_databroker.py" --junitxml=pytest_results.xml
 
 RESULT=$?
 


### PR DESCRIPTION
This adds necessary steps to upload the test results to codecov besides the coverage itself. It makes it more visible to people outside. They do not need to have a look into the actions console to see the test result and what has been tested.