### PR TITLE
Disable keep-alive in tcp connection

### DIFF
--- a/databroker/src/grpc/server.rs
+++ b/databroker/src/grpc/server.rs
@@ -11,7 +11,7 @@
 * SPDX-License-Identifier: Apache-2.0
 ********************************************************************************/
 
-use std::{convert::TryFrom, future::Future, time::Duration};
+use std::{convert::TryFrom, future::Future};
 
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
@@ -157,8 +157,8 @@ where
 
     let incoming = TcpListenerStream::new(listener);
     let mut server = Server::builder()
-        .http2_keepalive_interval(Some(Duration::from_secs(10)))
-        .http2_keepalive_timeout(Some(Duration::from_secs(20)));
+        .http2_keepalive_interval(None)
+        .http2_keepalive_timeout(None);
 
     #[cfg(feature = "tls")]
     match server_tls {


### PR DESCRIPTION
We've seen 40 ms spikes periodically when meassuring latency. It seems if you disable keep-alive signals in tcp this issue goes away.

!!! DRAFT !!!

Not entirely sure this is the best way to go since channels might be closing the connection. See https://grpc.io/docs/guides/performance/#general 

Will do some further tests. 