### PR TITLE
Pre-Commit hook for cargo fmt and clippy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,20 @@ repos:
         exclude: \.token$
     -   id: check-yaml
     -   id: check-added-large-files
+-   repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        description: Format files with rustfmt.
+        entry: bash -c 'cargo fmt -- --check'
+        language: rust
+      - id: cargo-check
+        name: cargo check
+        description: Check the package for errors.
+        entry: bash -c 'cargo check --all'
+        language: rust
+      - id: cargo-clippy
+        name: cargo clippy
+        description: Lint rust sources
+        entry: bash -c 'cargo clippy --all-targets -- -W warnings -D warnings'
+        language: rust


### PR DESCRIPTION
To prevent checks on GitHub PullRequests to fail due to formatting and linting errors (which also may be introduced or changed by updated cargo versions), they are added to the pre-commit hook by this PR.

Did not add any other cargo build, compile or test steps, as these are much more expensive and would increase the wait time for commits unnecessarily.