### PR TITLE
publish, set, actuate non-interactive cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Run the cli with:
 
 ### Reading and writing VSS data using the CLI (non-interactive)
 You can use the databroker-cli as non interactive client as well. If you call `help` on it then you get the available commands:
+
 ```sh
 Usage: databroker-cli [OPTIONS] [COMMAND]
 
@@ -268,7 +269,7 @@ exmaple invocation:
   docker run -it --rm --net=host ghcr.io/eclipse-kuksa/kuksa-databroker-cli:main --protocol kuksa.val.v1 publish Vehicle.Speed 12
   Using kuksa.val.v1
   [publish]  OK
-```  
+```
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The quickest possible way to get Kuksa Databroker up and running.
 *Note that not all APIs are enabled by default, see [user guide](doc/user_guide.md) and*
 *[protocols](doc/protocol.md) for more information!*
 
-### Reading and writing VSS data using the CLI
+### Reading and writing VSS data using the CLI (interactive)
 
 1. Start the CLI in a container attached to the _kuksa_ bridge network and connect to the Databroker container:
 
@@ -212,7 +212,7 @@ The quickest possible way to get Kuksa Databroker up and running.
    ```
 
    ```console
-   [set]  OK
+   [publish]  OK
    ```
 
 1. Get the vehicle's current speed
@@ -232,6 +232,43 @@ Run the cli with:
    ```sh
    quit
    ```
+
+
+### Reading and writing VSS data using the CLI (non-interactive)
+You can use the databroker-cli as non interactive client as well. If you call `help` on it then you get the available commands:
+```sh
+Usage: databroker-cli [OPTIONS] [COMMAND]
+
+Commands:
+  get      Get one or more datapoint(s)
+  set      Set a datapoint
+  publish  Publish a datapoint PATH VALUE
+  actuate  Request an actuation PATH VALUE
+  help     Print this message or the help of the given subcommand(s)
+
+Options:
+      --server <SERVER>      Server to connect to [default: http://127.0.0.1:55555]
+      --token-file <FILE>    File containing access token
+      --ca-cert <CERT>       CA certificate used to verify server certificate
+  -p, --protocol <PROTOCOL>  [default: kuksa.val.v1] [possible values: kuksa.val.v1, sdv.databroker.v1]
+  -h, --help                 Print help
+  -V, --version              Print version
+```
+support of the commands for non-interactive mode for kuksa.val.v1 and sdv.databroker.v1:
+| Operation                          | sdv.databroker.v1 | kuksa.val.v1 |
+|------------------------------------|--------------------|---------------|
+| `publish` to Databroker             | No                | Yes           |
+| `set` datapoint in Databroker          | No                | No           |
+| `actuate` request to Databroker             | No                 | Yes           |
+| `get` datapoint from Databroker | Yes                | Yes            |
+
+exmaple invocation:
+
+```sh
+  docker run -it --rm --net=host ghcr.io/eclipse-kuksa/kuksa-databroker-cli:main --protocol kuksa.val.v1 publish Vehicle.Speed 12
+  Using kuksa.val.v1
+  [publish]  OK
+```  
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/databroker-cli/src/cli.rs
+++ b/databroker-cli/src/cli.rs
@@ -90,18 +90,21 @@ pub enum Commands {
         #[clap(value_name = "PATH")]
         paths: Vec<String>,
     },
+    /// Set a datapoint
     Set {
         #[clap(value_name = "PATH")]
         path: String,
         #[clap(value_name = "VALUE")]
         value: String,
     },
+    /// Publish a datapoint PATH VALUE
     Publish {
         #[clap(value_name = "PATH")]
         path: String,
         #[clap(value_name = "VALUE")]
         value: String,
     },
+    /// Request an actuation PATH VALUE
     Actuate {
         #[clap(value_name = "PATH")]
         path: String,

--- a/databroker-cli/src/cli.rs
+++ b/databroker-cli/src/cli.rs
@@ -90,7 +90,24 @@ pub enum Commands {
         #[clap(value_name = "PATH")]
         paths: Vec<String>,
     },
-    // Subscribe,
+    Set {
+        #[clap(value_name = "PATH")]
+        path: String,
+        #[clap(value_name = "VALUE")]
+        value: String,
+    },
+    Publish {
+        #[clap(value_name = "PATH")]
+        path: String,
+        #[clap(value_name = "VALUE")]
+        value: String,
+    },
+    Actuate {
+        #[clap(value_name = "PATH")]
+        path: String,
+        #[clap(value_name = "VALUE")]
+        value: String,
+    },
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]

--- a/databroker-cli/src/kuksa_cli.rs
+++ b/databroker-cli/src/kuksa_cli.rs
@@ -124,12 +124,8 @@ async fn handle_actuate_command(
 
                 match client.set_target_values(datapoints).await {
                     Ok(_) => cli::print_resp_ok("actuate")?,
-                    Err(ClientError::Status(status)) => {
-                        cli::print_resp_err("actuate", &status)?
-                    }
-                    Err(ClientError::Connection(msg)) => {
-                        cli::print_error("actuate", msg)?
-                    }
+                    Err(ClientError::Status(status)) => cli::print_resp_err("actuate", &status)?,
+                    Err(ClientError::Connection(msg)) => cli::print_error("actuate", msg)?,
                     Err(ClientError::Function(msg)) => {
                         cli::print_resp_err_fmt("actuate", format_args!("Error {msg:?}"))?
                     }
@@ -167,15 +163,13 @@ async fn handle_publish_command(
             if let Some(metadata) = entry.metadata {
                 let data_value = try_into_data_value(
                     value,
-                    proto::v1::DataType::try_from(metadata.data_type)
-                        .unwrap(),
+                    proto::v1::DataType::try_from(metadata.data_type).unwrap(),
                 );
                 if data_value.is_err() {
                     println!(
                         "Could not parse \"{}\" as {:?}",
                         value,
-                        proto::v1::DataType::try_from(metadata.data_type)
-                            .unwrap()
+                        proto::v1::DataType::try_from(metadata.data_type).unwrap()
                     );
                     continue;
                 }
@@ -199,10 +193,7 @@ async fn handle_publish_command(
                         cli::print_error("publish", msg)?
                     }
                     Err(kuksa_common::ClientError::Function(msg)) => {
-                        cli::print_resp_err_fmt(
-                            "publish",
-                            format_args!("Error {msg:?}"),
-                        )?;
+                        cli::print_resp_err_fmt("publish", format_args!("Error {msg:?}"))?;
                     }
                 }
             }
@@ -311,16 +302,16 @@ pub async fn kuksa_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     match cli.get_command() {
         Some(cli::Commands::Get { paths }) => {
             return handle_get_command(paths, &mut client).await;
-        },
+        }
         Some(cli::Commands::Set { path, value }) => {
             return handle_publish_command(&path, &value, &mut client).await;
-        },
+        }
         Some(cli::Commands::Actuate { path, value }) => {
             return handle_actuate_command(&path, &value, &mut client).await;
-        },
+        }
         Some(cli::Commands::Publish { path, value }) => {
             return handle_publish_command(&path, &value, &mut client).await;
-        },
+        }
         None => {
             // No subcommand => run interactive client
             let version = match option_env!("CARGO_PKG_VERSION") {
@@ -385,7 +376,7 @@ pub async fn kuksa_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                                 .split_whitespace()
                                 .map(|path| path.to_owned())
                                 .collect();
-                            
+
                             handle_get_command(paths, &mut client).await?
                         }
                         "gettarget" => {

--- a/databroker-cli/src/kuksa_cli.rs
+++ b/databroker-cli/src/kuksa_cli.rs
@@ -303,8 +303,8 @@ pub async fn kuksa_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Some(cli::Commands::Get { paths }) => {
             return handle_get_command(paths, &mut client).await;
         }
-        Some(cli::Commands::Set { path, value }) => {
-            return handle_publish_command(&path, &value, &mut client).await;
+        Some(cli::Commands::Set { path: _, value: _ }) => {
+            unimplemented!("The set command is not implemented for kuksa.val.v1 protocol because it is not intended to be named like this anymore. Use publish instead.");
         }
         Some(cli::Commands::Actuate { path, value }) => {
             return handle_actuate_command(&path, &value, &mut client).await;

--- a/databroker-cli/src/sdv_cli.rs
+++ b/databroker-cli/src/sdv_cli.rs
@@ -155,13 +155,13 @@ pub async fn sdv_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             return handle_get_command(paths, &mut client).await;
         }
         Some(cli::Commands::Set { path: _, value: _ }) => {
-            unimplemented!("The Set command is not implemented for sdv.databroker.v1 protocol because it is already deprecated.");
+            unimplemented!("The set command is not implemented for sdv.databroker.v1 protocol because it is already deprecated.");
         }
         Some(cli::Commands::Publish { path: _, value: _ }) => {
-            unimplemented!("The Publish command is not implemented for sdv.databroker.v1 protocol because it is already deprecated.");
+            unimplemented!("The publish command is not implemented for sdv.databroker.v1 protocol because it is already deprecated.");
         }
         Some(cli::Commands::Actuate { path: _, value: _ }) => {
-            unimplemented!("The Actuate command is not implemented for sdv.databroker.v1 protocol because it is already deprecated.");
+            unimplemented!("The actuate command is not implemented for sdv.databroker.v1 protocol because it is already deprecated.");
         }
         None => {
             // No subcommand => run interactive client

--- a/databroker-cli/src/sdv_cli.rs
+++ b/databroker-cli/src/sdv_cli.rs
@@ -66,7 +66,10 @@ fn print_usage(command: impl AsRef<str>) {
     }
 }
 
-async fn handle_get_command(paths: Vec<String>, client: &mut SDVClient) -> Result<(), Box<dyn std::error::Error>>{
+async fn handle_get_command(
+    paths: Vec<String>,
+    client: &mut SDVClient,
+) -> Result<(), Box<dyn std::error::Error>> {
     match client.get_datapoints(paths).await {
         Ok(datapoints) => {
             cli::print_resp_ok("get")?;
@@ -150,16 +153,16 @@ pub async fn sdv_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     match cli.get_command() {
         Some(cli::Commands::Get { paths }) => {
             return handle_get_command(paths, &mut client).await;
-        },
+        }
         Some(cli::Commands::Set { path: _, value: _ }) => {
             unimplemented!("The Set command is not implemented for sdv.databroker.v1 protocol because it is already deprecated.");
-        },
+        }
         Some(cli::Commands::Publish { path: _, value: _ }) => {
             unimplemented!("The Publish command is not implemented for sdv.databroker.v1 protocol because it is already deprecated.");
-        },
+        }
         Some(cli::Commands::Actuate { path: _, value: _ }) => {
             unimplemented!("The Actuate command is not implemented for sdv.databroker.v1 protocol because it is already deprecated.");
-        },
+        }
         None => {
             // No subcommand => run interactive client
             let version = match option_env!("CARGO_PKG_VERSION") {


### PR DESCRIPTION
Adds `publish` `actuate` `set` from cli for kuksa.val.v1 `set` calls the same as `publish`.

calls like these are now supported:
```
cargo run --bin databroker-cli -- --protocol kuksa.val.v1 publish Vehicle.Speed 12
   Compiling databroker-cli v0.6.0-dev.0 (/home/imu6fe/kuksa-databroker/databroker-cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.67s
     Running `target/debug/databroker-cli --protocol kuksa.val.v1 publish Vehicle.Speed 12`
Using kuksa.val.v1
[publish]  OK  
```
```
cargo run --bin databroker-cli -- --protocol kuksa.val.v1 actuate Vehicle.ADAS.CruiseControl.SpeedSet 11
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.17s
     Running `target/debug/databroker-cli --protocol kuksa.val.v1 actuate Vehicle.ADAS.CruiseControl.SpeedSet 11`
Using kuksa.val.v1
[actuate]  OK  
```
same for docker:
```
docker run -it --rm --net=host ghcr.io/eclipse-kuksa/kuksa-databroker-cli:main --protocol kuksa.val.v1 publish Vehicle.Speed 12`
Using kuksa.val.v1
[publish]  OK  
```