### PR TITLE
Tests for COVESA VISS v2 server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__
 databroker/thirdparty
 databroker-cli/thirdparty
 .venv/
+allure-results/
+.pytest_cache/

--- a/integration_test/viss/STEPS.md
+++ b/integration_test/viss/STEPS.md
@@ -1,0 +1,214 @@
+# Step Definitions
+
+The steps in the test scenarios follow the following Gherkin syntax:
+
+## Parameters
+
+> _VSS Path_: A VSS data point path in the "`Vehicle.Branch.Leaf`" syntax.
+
+## Given
+
+> Given I am authorized
+
+The client will have an authorized token when communicating with the VISS server.
+
+> Given I am authorized to read "_VSS Path_"
+
+Authorize with a token which allows to read the given VSS path.
+
+> Given the VISS server is running
+
+The client will test that the VISS server is up and running. The test step actually doesn't do anything and this is more for readability of the test cases.
+
+> Given the VISS client is connected via HTTP
+
+The client will connect to the VISS server using the HTTP channel.
+
+> Given the VISS client is connected via WebSocket
+
+The client will connect to the VISS server using the WebSocket channel.
+
+> Given the VISS client is connected via MQTT
+
+The client will connect to the VISS server using the MQTT channel.
+
+> Given I have a subscription to "_VSS Path_"
+
+  _VSS Path_: A VSS path, such as "Vehicle.Speed"
+
+> Given "_VSS Path_" has been updated multiple times over the past _minutes_ minutes
+
+  _minutes_: A decimal number of minutes, e.g. 10
+
+## When
+
+> When I send a subscription request for "_VSS Path_"
+
+Subscribes to the given VSS path.
+
+> When I subscribe to "_VSS Path_" using a curvelog filter with maxerr _maxerr value_ and bufsize _bufsize value_
+
+  _maxerr value_ and _bufsize value_: numberic values as specified in VISSv2
+
+> When I send an unsubscribe request
+
+Unsubscribe to no longer receive VSS data point updates.
+
+> When I send a read request with path "_VSS Path_"
+
+Get a value of a data pointo once.
+
+> When I search "_VSS Path_" using a path filter "_Path Filter_"
+
+  _Path Filter_: A VSS path notation, potentially with wildcards, e.g. "`Vehicle.*`"
+
+> When I search "_VSS Path_" using a history filter "_History Filter_"
+
+  _History Filter_: As specified in VISSv2 ISO8601, e.g. P2DT12H
+
+> When I search "_VSS Path_" using a dynamic metadata filter "_dynamic metadata filter_"
+
+  _dynamic metadata filter_: As specified in VISSv2, e.g. `availability`, `validate`, ...
+
+> When I search "_VSS Path_" using a static metadata filter "_static metadata filter_"
+
+  _static metadata filter_: As specified in VISSv2
+
+> When I subscribe to "_VSS Path_" using a range filter
+
+Only receive updates to the VSS data point when the value is within the range filter.
+
+> When I subscribe to "_VSS Path_" using a change filter
+
+Only receive updates to a VSS data point when the delta change of a value reaches a threshold.
+
+> When I send a set request for path "_VSS Path_" with the value _datapoint value_
+
+  _datapoint value_: The string representation of the new value to be set
+
+> When "_VSS Path_" has been updated multiple times over the past _minutes_ minutes
+
+  _minutes_: Decimal number for minutes
+
+> When I request historical data for "_VSS Path_" with a timeframe of "_timeframe_"
+
+  _timeframe_: In ISO8601 format as specified in VISSv2, e.g. P2DT12H
+
+> When I send a bulk set request with the following values: _datatable on new line_
+
+  _datatable_: A table, rows are signals. First column is VSS Path, Second column is new data point value to set.
+
+## Then
+
+> Then I should receive a valid response
+
+Validate the server response to be a successful response, e.g. no error.
+
+> Then I should receive a valid read response
+
+Server response is valid and a response to a read request.
+
+> Then I should receive a single value from a single node
+
+Successfully read a single value for a single data point.
+
+> Then I should receive multiple data points
+
+The response from the server must contain multiple data points.
+
+> Then I should receive a single value from multiple nodes
+
+The response contains a single value for each of the request data points.
+
+> Then I should receive exactly _expected count of data points_ data points
+
+  _expected count of data points_: Decimal number of data point values to expect
+
+> Then I should receive an error response
+
+Expect the server to respond with an error message.
+
+> Then I should receive an error response with number _error code_ and reason "_error reason_"
+
+  _error code_: Numeric error code, such as 404
+  _error reason_: Error reason, such as "invalid_value"
+
+> Then I should receive a valid subscribe response
+
+The server acknowledges the success of subscribing to a VSS path.
+
+> Then I should receive a valid subscription response
+
+The server asynchronously reports a data point value from a previous subscription.
+
+> Then I should receive a subscribe error event
+
+Subscribing to a data point was unsuccessful.
+
+> Then I should receive a set error event
+
+The server declined setting the value of a data point.
+
+> Then I should receive a valid unsubscribe response
+
+Acknowledge the client to have unsubscribed from a data point.
+
+> Then I should receive a valid subscription event
+
+Server responds with a successful event from a subscription.
+
+> Then I should receive a valid set response
+
+Server acknowledges to have updated a data point.
+
+> Then I should receive a valid set response for "_VSS Path_"
+
+Server acknowledges to have updated the specified data point.
+
+> Then I should receive a read-only error
+
+Server declines to update, as the data point is a read-only signal.
+
+> Then I should receive a list of server capabilities
+
+Server responds with a list of capabilities.
+
+> Then I request historical data for "_VSS Path_" with a timeframe of "_timeframe_"
+
+Server responds with a timeline of data points within the given time period.
+
+> Then I should receive a list of past data points within the last hour
+
+Server responds with a timeline of data points within the given time period.
+
+> Then I should receive multiple past data points from the last 24 hours
+
+Server responds with a timeline of data points within the given time period.
+
+> Then the timestamps should be in chronological order
+
+The reply of the server is ordered in chronological order of the data point updates.
+
+> Then I should receive an error response indicating an invalid timeframe format
+
+Server declines the request as the client provided a syntactically incorrect time duration.
+
+> Then I should receive an empty data response
+
+Validate that the server response is empty.
+
+> Then I should receive a set of past data points matching the recorded values
+
+Validate the server response to contain expected data points.
+
+> Then the values should be accurate compared to previous set requests
+
+Validate the server response to contain expected data points.
+
+> Then I should receive historical data for multiple nodes
+
+Validate the server response to contain expected historical data points.
+
+> Then the response should include data from at least two different paths
+
+Validate the server response to contain different vehicle signals.

--- a/integration_test/viss/conftest.py
+++ b/integration_test/viss/conftest.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# /********************************************************************************
+# * Copyright (c) 2025 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+import asyncio
+import requests
+import pytest
+import logging
+
+# Basic logging
+logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+# Fail early if databroker is not up and running
+@pytest.fixture(autouse=True, scope='session')
+def check_databroker_connect_http_url(pytestconfig):
+    # setup
+    url = pytestconfig.getini("viss_http_base_url")
+    try:
+        requests.get(url, timeout=float(pytestconfig.getini("viss_connect_timeout")))
+    except requests.exceptions.ConnectionError:
+        logger.error("Databroker not running, exiting...")
+        pytest.exit(f"FATAL: Databroker not running at {url}")
+
+# Additional custom configuratio parameters
+def pytest_addoption(parser):
+    parser.addini('viss_ws_base_url', 'URL to Databroker VISS WebSocket endpoint (ws://hostname:port)', type="string", default="ws://localhost:8090")
+    parser.addini('viss_http_base_url', 'URL to Databroker VISS HTTP endpoint (http://hostname:port)', type="string", default="http://localhost:8090")
+    parser.addini('viss_mqtt_base_url', 'URL to Databroker VISS MQTT endpoint (mqtt://hostname:port)', type="string", default="mqtt://localhost:1883")
+    parser.addini('viss_connect_timeout', 'Connect timeout for VISS clients (float in seconds)', type="string", default="1.0")
+    parser.addini('viss_message_timeout', 'Connect timeout for VISS clients (float in seconds)', type="string", default="0.5")

--- a/integration_test/viss/features/viss_v2_basic.feature
+++ b/integration_test/viss/features/viss_v2_basic.feature
@@ -1,0 +1,62 @@
+#
+# https://w3c.github.io/automotive/spec/VISSv2_Core.html#read
+#
+
+Feature: VISS v2 Compliance Testing - Basic
+
+  Background:
+    Given the VISS server is running
+    Given the VISS client is connected via WebSocket
+
+  # 5.1.2 Read request
+  # The VISS server must support read requests to retrieve data from a valid path.
+  @MustHave
+  Scenario: Read a valid data path
+    When I send a read request with path "Vehicle.Speed"
+    Then I should receive a valid read response
+
+  # 5.1.3 Subscribe request
+  # The VISS server must support subscriptions to receive data updates.
+  @MustHave
+  Scenario: Subscribe to a data path
+    When I send a subscription request for "Vehicle.Speed"
+    Then I should receive a valid subscribe response
+
+  # 5.1.3 Subscribe request - Error handling
+  # The VISS server must return an error when subscribing to an invalid data path.
+  @MustHave
+  Scenario: Subscribe to an unknown data path
+    When I send a subscription request for "Some.Unknown.Datapoint"
+    Then I should receive a subscribe error event
+
+  # 5.1.3 Subscribe request & 5.1.4 Set request
+  # The VISS server must notify subscribers of data updates and enforce read-only restrictions.
+  @MustHave
+  Scenario: Subscribe and update a data path
+    When I send a subscription request for "Vehicle.Speed"
+    Then I should receive a valid subscribe response
+    When I send a set request for path "Vehicle.Speed" with the value 123
+    Then I should receive a valid subscription event
+    Then I should receive a read-only error
+
+  # 5.1.3 Subscribe request - Unsubscribe
+  # The VISS server must support unsubscribing from an existing subscription.
+  @MustHave
+  Scenario: Subscribe and Unsubscribe
+    Given I have a subscription to "Vehicle.Speed"
+    When I send an unsubscribe request
+    Then I should receive a valid unsubscribe response
+
+  # 5.1.4 Set request - Read-only restriction
+  # The VISS server must reject set requests to read-only signals.
+  @MustHave
+  Scenario: Setting a read-only signal (sensor)
+    When I send a set request for path "Vehicle.Speed" with the value 80
+    Then I should receive a read-only error
+
+  # 5.1.4 Set request - Writing to actuators
+  # The VISS server must allow set requests to writable signals (actuators).
+  @MustHave
+  Scenario: Setting a writable signal (actuator)
+    When I send a set request for path "Vehicle.Cabin.Infotainment.HMI.FontSize" with the value LARGE
+    Then I should receive a valid set response

--- a/integration_test/viss/features/viss_v2_bulk_updates.feature
+++ b/integration_test/viss/features/viss_v2_bulk_updates.feature
@@ -1,0 +1,49 @@
+Feature: VISS v2 Compliance Testing - Bulk Updates
+
+  Background:
+    Given the VISS server is running
+    Given the VISS client is connected via WebSocket
+
+  Scenario: Bulk update multiple writable signals successfully
+    When I send a bulk set request with the following values:
+        | Path | Value |
+        | Vehicle.Cabin.Infotainment.HMI.FontSize | LARGE |
+        | Vehicle.Cabin.TemperatureSetpoint | 22 |
+    Then I should receive a valid set response for "Vehicle.Cabin.Infotainment.HMI.FontSize"
+    Then I should receive a valid set response for "Vehicle.Cabin.TemperatureSetpoint"
+
+  Scenario: Bulk update with a mix of writable and read-only signals
+    When I send a bulk set request with the following values:
+        | Path | Value |
+        | Vehicle.Cabin.Infotainment.HMI.FontSize | LARGE |
+        | Vehicle.Speed | 100 |
+    Then I should receive a valid set response for "Vehicle.Cabin.Infotainment.HMI.FontSize"
+    And I should receive a read-only error for "Vehicle.Speed"
+
+  Scenario: Bulk update with an invalid signal path
+    When I send a bulk set request with the following values:
+        | Path | Value |
+        | Vehicle.Cabin.Infotainment.HMI.FontSize | MEDIUM |
+        | Some.Unknown.Datapoint | 50 |
+    Then I should receive a valid set response for "Vehicle.Cabin.Infotainment.HMI.FontSize"
+    And I should receive an error response with number 404 and reason "invalid_path" for "Some.Unknown.Datapoint"
+
+  Scenario: Bulk update with partial failure
+    When the system enforces atomicity for bulk updates
+    When I send a bulk set request with the following values:
+        | Path | Value |
+        | Vehicle.Cabin.Infotainment.HMI.FontSize | SMALL |
+        | Vehicle.Speed | 120 |
+        | Some.Unknown.Datapoint | 30 |
+    Then the entire bulk update should be rejected
+    And I should receive an error response indicating partial failure
+
+  Scenario: Bulk update with multiple writable signals over HTTP
+    Given the VISS server is running
+    And the VISS client is connected via HTTP
+    When I send a bulk set request with the following values:
+        | Path | Value |
+        | Vehicle.Cabin.Lights.Intensity | HIGH |
+        | Vehicle.Cabin.TemperatureSetpoint | 21 |
+    Then I should receive a valid response
+    And the values should be updated in the system

--- a/integration_test/viss/features/viss_v2_core_authorization.feature
+++ b/integration_test/viss/features/viss_v2_core_authorization.feature
@@ -1,0 +1,25 @@
+#
+# https://w3c.github.io/automotive/spec/VISSv2_Core.html#access-control-model
+#
+
+Feature: VISS v2 Compliance Testing - Authorization
+
+  Background:
+    Given the VISS server is running
+    Given the VISS client is connected via WebSocket
+
+  # 8.3.1 Access Grant Request
+  # The request shall contain the Context and Proof parameters
+  @MustHave
+  Scenario: Authorized reading of a valid data path
+    Given I am authorized to read "Vehicle.Speed"
+    When I send a read request with path "Vehicle.Speed"
+    Then I should receive a valid read response
+
+  # 8.4.4 Access Control Server
+  # For client requests that are not granted due to access control, the VISSv2 server MUST return one of the error codes shown in the table below.
+  @MustHave
+  Scenario: Authorized, but insufficient permissions
+    Given I am authorized to read "Vehicle.Speed"
+    When I send a read request with path "Vehicle.VIN"
+    Then I should receive an error response

--- a/integration_test/viss/features/viss_v2_core_read.feature
+++ b/integration_test/viss/features/viss_v2_core_read.feature
@@ -1,0 +1,30 @@
+#
+# https://w3c.github.io/automotive/spec/VISSv2_Core.html#read
+#
+
+Feature: VISS v2 Compliance Testing - Core: Read
+
+  Background:
+    Given the VISS server is running
+    Given the VISS client is connected via WebSocket
+
+  # 5.1.2 Read request
+  # The VISS server must support read requests to retrieve data from a valid path.
+  @MustHave
+  Scenario: Read a valid data path (Vehicle.VehicleIdentification.VIN)
+    When I send a read request with path "Vehicle.VehicleIdentification.VIN"
+    Then I should receive a valid read response
+
+  # 5.1.2 Read request - Error handling
+  # The VISS server must return an error when attempting to read an invalid data path.
+  @MustHave
+  Scenario: Read an invalid data path
+    When I send a read request with path "Some.Unknown.Datapoint"
+    Then I should receive an error response
+
+  # 5.1.2 Read request - Wildcards not allowed
+  # The VISS server must reject read requests containing wildcard characters.
+  @MustHave
+  Scenario: Path must not contain any wildcards
+    When I send a read request with path "Vehicle.*"
+    Then I should receive an error response

--- a/integration_test/viss/features/viss_v2_core_subscribe.feature
+++ b/integration_test/viss/features/viss_v2_core_subscribe.feature
@@ -1,0 +1,32 @@
+#
+# https://w3c.github.io/automotive/spec/VISSv2_Core.html#subscribe
+#
+
+Feature: VISS v2 Compliance Testing - Core: Subscribe
+
+  Background:
+    Given the VISS server is running
+    Given the VISS client is connected via WebSocket
+
+  # 5.1.3 Subscribe request
+  # The VISS server must support subscriptions to receive data updates.
+  @MustHave
+  Scenario: Subscribe to a data path
+    When I send a subscription request for "Vehicle.Speed"
+    Then I should receive a valid subscribe response
+    Then I should receive a valid subscription response
+
+  # 5.1.3 Subscribe request - Error handling
+  # The VISS server must return an error when subscribing to an invalid data path.
+  @MustHave
+  Scenario: Subscribe to an unknown data path
+    When I send a subscription request for "Some.Unknown.Datapoint"
+    Then I should receive a subscribe error event
+
+  # 5.1.3 Subscribe request - Unsubscribe
+  # The VISS server must support unsubscribing from an existing subscription.
+  @MustHave
+  Scenario: Subscribe and Unsubscribe
+    Given I have a subscription to "Vehicle.Speed"
+    When I send an unsubscribe request
+    Then I should receive a valid unsubscribe response

--- a/integration_test/viss/features/viss_v2_core_unsubscribe.feature
+++ b/integration_test/viss/features/viss_v2_core_unsubscribe.feature
@@ -1,0 +1,17 @@
+#
+# https://w3c.github.io/automotive/spec/VISSv2_Core.html#unsubscribe
+#
+
+Feature: VISS v2 Compliance Testing - Core: Unsubscribe
+
+  Background:
+    Given the VISS server is running
+    Given the VISS client is connected via WebSocket
+    Given I have a subscription to "Vehicle.Speed"
+
+  # 5.1.3 Subscribe request - Unsubscribe
+  # The VISS server must support unsubscribing from an existing subscription.
+  @MustHave
+  Scenario: Unsubscribe
+    When I send an unsubscribe request
+    Then I should receive a valid unsubscribe response

--- a/integration_test/viss/features/viss_v2_core_update.feature
+++ b/integration_test/viss/features/viss_v2_core_update.feature
@@ -1,0 +1,26 @@
+#
+# https://w3c.github.io/automotive/spec/VISSv2_Core.html#update
+#
+
+Feature: VISS v2 Compliance Testing - Core: Update
+
+  Background:
+    Given the VISS server is running
+    Given the VISS client is connected via WebSocket
+
+  # 5.1.4 Set request - Writing to actuators
+  # The VISS server must allow set requests to writable signals (actuators).
+  @MustHave
+  Scenario: Updating an actuator
+    When I send a set request for path "Vehicle.Cabin.Infotainment.HMI.FontSize" with the value LARGE
+    Then I should receive a valid set response
+
+  # 5.1.4 Set request & 5.1.3 Subscribe request
+  # The VISS server must notify subscribers of data updates and enforce read-only restrictions where applicable.
+  @MustHave
+  Scenario: Subscribe and update a data path
+    When I send a subscription request for "Vehicle.Speed"
+    Then I should receive a valid subscribe response
+    When I send a set request for path "Vehicle.Speed" with the value 123
+    Then I should receive a valid subscription event
+    Then I should receive a read-only error

--- a/integration_test/viss/features/viss_v2_history_data.feature
+++ b/integration_test/viss/features/viss_v2_history_data.feature
@@ -1,0 +1,55 @@
+#
+# https://w3c.github.io/automotive/spec/VISSv2_Core.html#update
+#
+
+Feature: VISS v2 Compliance Testing - History Data
+
+    Background:
+        Given the VISS server is running
+        Given the VISS client is connected via WebSocket
+
+    # 5.1.4 Set request - Writing to actuators
+    # The VISS server should support retrieving historical data when a valid request is made for a data point.
+    @ShouldHave
+    Scenario: Retrieve history for a single data point over the last hour
+        When I request historical data for "Vehicle.Speed" with a timeframe of "PT1H"
+        Then I should receive a list of past data points within the last hour
+        And the timestamps should be in chronological order
+
+    # 5.1.4 Set request - Writing to actuators
+    # The VISS server should support retrieving historical data when a valid request is made for multiple data points.
+    @ShouldHave
+    Scenario: Retrieve history for multiple data points over a day
+        When I request historical data for "Vehicle.Cabin.TemperatureSetpoint" with a timeframe of "P1D"
+        Then I should receive multiple past data points from the last 24 hours
+
+    # 5.1.2 Read request - Error handling
+    # The VISS server must return an error when requesting historical data with an invalid timeframe format.
+    @MustHave
+    Scenario: Retrieve history with an invalid timeframe format
+        When I request historical data for "Vehicle.Speed" with a timeframe of "INVALID"
+        Then I should receive an error response indicating an invalid timeframe format
+
+    # 5.1.2 Read request - No data available
+    # The VISS server should return an empty data response when no data is available for the requested timeframe.
+    @ShouldHave
+    Scenario: Retrieve history when no data is available
+        When I request historical data for "Vehicle.Speed" with a timeframe of "P1Y"
+        Then I should receive an empty data response
+
+    # 5.1.4 Set request - Writing to actuators
+    # The VISS server should return accurate historical data for a data point that has been updated recently.
+    @ShouldHave
+    Scenario: Retrieve history and verify data consistency
+        When "Vehicle.Speed" has been updated multiple times over the past 10 minutes
+        And I request historical data for "Vehicle.Speed" with a timeframe of "PT10M"
+        Then I should receive a set of past data points matching the recorded values
+        And the values should be accurate compared to previous set requests
+
+    # 5.1.2 Read request - Wildcards allowed
+    # The VISS server may allow retrieving historical data for multiple nodes at once.
+    @ShouldHave
+    Scenario: Retrieve history for multiple nodes
+        When I request historical data for "Vehicle.*" with a timeframe of "P1D"
+        Then I should receive historical data for multiple nodes
+        And the response should include data from at least two different paths

--- a/integration_test/viss/features/viss_v2_multiple_paths.feature
+++ b/integration_test/viss/features/viss_v2_multiple_paths.feature
@@ -1,0 +1,38 @@
+#
+# https://w3c.github.io/automotive/spec/VISSv2_Core.html#read
+#
+
+Feature: VISS v2 Compliance Testing - Multiple Paths
+
+  Background:
+    Given the VISS server is running
+    Given the VISS client is connected via WebSocket
+
+  # 5.1.2 Read request - Single value request
+  # The VISS server must support reading a single value from a valid data path.
+  @MustHave
+  Scenario: Request for a single value from a single node
+    When I send a read request with path "Vehicle.Speed"
+    Then I should receive a single value from a single node
+
+  # 5.1.2 Read request - Multiple values from a single node
+  # The VISS server should support reading multiple values from a single data node.
+  @ShouldHave
+  Scenario: Request for multiple values from a single node
+    # This scenario can be expanded based on specific use cases.
+    When I send a read request with path "Vehicle.Cabin.TemperatureSetpoint"
+    Then I should receive multiple values from a single node
+
+  # 5.1.2 Read request - Single value request from multiple nodes
+  # The VISS server must support reading values from multiple nodes using path filters.
+  @MustHave
+  Scenario: Request for a single value from multiple nodes
+    When I search "Vehicle" using a path filter "*"
+    Then I should receive a single value from multiple nodes
+
+  # 5.1.2 Read request - Multiple values from multiple nodes
+  # The VISS server should support reading multiple values from multiple nodes.
+  @ShouldHave
+  Scenario: Request for multiple values from multiple nodes
+    When I send a read request with path "Vehicle.*"
+    Then I should receive multiple values from multiple nodes

--- a/integration_test/viss/features/viss_v2_server_capabilities.feature
+++ b/integration_test/viss/features/viss_v2_server_capabilities.feature
@@ -1,0 +1,16 @@
+#
+# https://w3c.github.io/automotive/spec/VISSv2_Core.html#server-capabilities
+#
+
+Feature: VISS v2 Compliance Testing - Server Capabilities
+
+  Background:
+    Given the VISS server is running
+    Given the VISS client is connected via WebSocket
+
+  # 5.1.5 Server Capabilities
+  # The VISS server must support the retrieval of server capabilities through a dynamic metadata filter.
+  @MustHave
+  Scenario: Requesting server capabilities
+    When I search "Vehicle" using a dynamic metadata filter "server_capabilities"
+    Then I should receive a list of server capabilities

--- a/integration_test/viss/features/viss_v2_transport_http_read.feature
+++ b/integration_test/viss/features/viss_v2_transport_http_read.feature
@@ -1,0 +1,24 @@
+#
+# https://www.w3.org/TR/viss2-transport/#wss-service-discovery-read
+#
+
+Feature: VISS v2 Compliance Testing - Transport: HTTP
+
+  Background:
+    Given the VISS server is running
+    Given the VISS client is connected via HTTP
+
+  # 5.2.1 Read request - Error handling
+  # The VISS server must return an error response when requesting an invalid data path via HTTP.
+  @MustHave
+  Scenario: Read an invalid data path from HTTP
+      When I send a read request with path "Some.Unknown.Datapoint"
+      Then I should receive an error response
+      Then I should receive an error response with number 404 and reason "invalid_path"
+
+  # 5.2.1 Read request - Valid request handling
+  # The VISS server must return a valid response when requesting a valid data path via HTTP.
+  @MustHave
+  Scenario: Read a valid data path from HTTP
+      When I send a read request with path "Vehicle.Speed"
+      Then I should receive a valid read response

--- a/integration_test/viss/features/viss_v2_transport_mqtt_read.feature
+++ b/integration_test/viss/features/viss_v2_transport_mqtt_read.feature
@@ -1,0 +1,27 @@
+#
+# https://www.w3.org/TR/viss2-transport/#wss-service-discovery-read
+#
+# Note: The scenarios are marked with ShouldHave, as supporting the MQTT protocol is optional.
+# The basic operations itself are mandatory, such as reading a data point. Those tests are in separate gherkin features files.
+#
+
+Feature: VISS v2 Compliance Testing - Transport: MQTT
+
+  Background:
+    Given the VISS server is running
+    Given the VISS client is connected via MQTT
+
+  # 5.2.1 Read request - Error handling
+  # The VISS server must return an error response when requesting an invalid data path via MQTT.
+  @ShouldHave
+  Scenario: Read an invalid data path from MQTT
+      When I send a read request with path "Some.Unknown.Datapoint"
+      Then I should receive an error response
+      Then I should receive an error response with number 404 and reason "invalid_path"
+
+  # 5.2.1 Read request - Valid request handling
+  # The VISS server must return a valid response when requesting a valid data path via MQTT.
+  @ShouldHave
+  Scenario: Read a valid data path from MQTT
+      When I send a read request with path "Vehicle.Speed"
+      Then I should receive a valid read response

--- a/integration_test/viss/features/viss_v2_transport_wss_filter.feature
+++ b/integration_test/viss/features/viss_v2_transport_wss_filter.feature
@@ -1,0 +1,61 @@
+#
+# https://www.w3.org/TR/viss2-transport/#wss-service-discovery-read
+#
+
+Feature: VISS v2 Compliance Testing - Filter
+
+  Background:
+    Given the VISS server is running
+    Given the VISS client is connected via WebSocket
+
+  # 5.2.2 Search by dynamic metadata filter
+  # The VISS server must support searching using dynamic metadata filters (e.g., availability) and return multiple data points.
+  @MustHave
+  Scenario: Search by dynamic metadata
+    When I search "Vehicle" using a dynamic metadata filter "availability"
+    Then I should receive multiple data points
+
+  # 5.2.3 Search by static metadata filter
+  # The VISS server should support searching using static metadata filters (e.g., datatype) and return multiple data points.
+  @ShouldHave
+  Scenario: Search by static metadata
+    When I search "Vehicle" using a static metadata filter "datatype"
+    Then I should receive multiple data points
+
+  # 5.3.1 Accessing recorded data with history filter
+  # The VISS server must support accessing recorded data points using a history filter (e.g., P2DT12H for 2 days and 12 hours).
+  @MustHave
+  Scenario: Access recorded data points using a history filter
+    When I search "Vehicle" using a history filter "P2DT12H"
+    Then I should receive multiple data points
+
+  # 5.4.1 Search for multiple signals using path filter
+  # The VISS server must support searching for multiple signals using a path filter (e.g., "*.IsOpen").
+  @MustHave
+  Scenario: Search for multiple signals using path filter
+    When I search "Vehicle" using a path filter "*.IsOpen"
+    Then I should receive multiple data points
+
+  # 5.5.1 Subscribe with change filter
+  # The VISS server must support subscription with a change filter and return a valid subscribe response and subscription event.
+  @MustHave
+  Scenario: Subscribe with change filter
+    When I subscribe to "Vehicle.Speed" using a change filter
+    Then I should receive a valid subscribe response
+    And I should receive a valid subscription event
+
+  # 5.6.1 Subscribe with curve logging filter
+  # The VISS server must support subscribing with a curve logging filter and return a valid subscribe response with the correct number of data points.
+  @MustHave
+  Scenario: Subscribe with curve logging
+    When I subscribe to "Vehicle.Speed" using a curvelog filter with maxerr 0.5 and bufsize 100
+    Then I should receive a valid subscribe response
+    And I should receive exactly 100 data points
+
+  # 5.7.1 Subscribe with range filter
+  # The VISS server must support subscribing with a range filter and return a valid subscribe response and subscription event.
+  @MustHave
+  Scenario: Subscribe with range filter
+    When I subscribe to "Vehicle.Speed" using a range filter
+    Then I should receive a valid subscribe response
+    And I should receive a valid subscription event

--- a/integration_test/viss/features/viss_v3_basic.feature
+++ b/integration_test/viss/features/viss_v3_basic.feature
@@ -1,0 +1,62 @@
+#
+# https://raw.githack.com/COVESA/vehicle-information-service-specification/main/spec/VISSv3.0_Core.html
+#
+
+Feature: VISS v3 Compliance Testing - Basic operations
+
+  Background:
+    Given the VISS server is running
+    Given the VISS client is connected via WebSocket
+
+  # 5.1.1 Read
+  # Purpose: Get one or more values addressed by the given path.
+  @MustHave
+  Scenario: Read a valid data path
+    When I send a read request with path "Vehicle.Speed"
+    Then I should receive a valid read response
+
+  # 5.1.3 Subscribe request
+  # The VISS server must support subscriptions to receive data updates.
+  @MustHave
+  Scenario: Subscribe to a data path
+    When I send a subscription request for "Vehicle.Speed"
+    Then I should receive a valid subscribe response
+
+  # 5.1.3 Subscribe request - Error handling
+  # The VISS server must return an error when subscribing to an invalid data path.
+  @MustHave
+  Scenario: Subscribe to an unknown data path
+    When I send a subscription request for "Some.Unknown.Datapoint"
+    Then I should receive a subscribe error event
+
+  # 5.1.3 Subscribe request & 5.1.4 Set request
+  # The VISS server must notify subscribers of data updates and enforce read-only restrictions.
+  @MustHave
+  Scenario: Subscribe and update a data path
+    When I send a subscription request for "Vehicle.Speed"
+    Then I should receive a valid subscribe response
+    When I send a set request for path "Vehicle.Speed" with the value 123
+    Then I should receive a valid subscription event
+    Then I should receive a read-only error
+
+  # 5.1.3 Subscribe request - Unsubscribe
+  # The VISS server must support unsubscribing from an existing subscription.
+  @MustHave
+  Scenario: Subscribe and Unsubscribe
+    Given I have a subscription to "Vehicle.Speed"
+    When I send an unsubscribe request
+    Then I should receive a valid unsubscribe response
+
+  # 5.1.4 Set request - Read-only restriction
+  # The VISS server must reject set requests to read-only signals.
+  @MustHave
+  Scenario: Setting a read-only signal (sensor)
+    When I send a set request for path "Vehicle.Speed" with the value 80
+    Then I should receive a read-only error
+
+  # 5.1.4 Set request - Writing to actuators
+  # The VISS server must allow set requests to writable signals (actuators).
+  @MustHave
+  Scenario: Setting a writable signal (actuator)
+    When I send a set request for path "Vehicle.Cabin.Infotainment.HMI.FontSize" with the value LARGE
+    Then I should receive a valid set response

--- a/integration_test/viss/features/viss_v3_core_read.feature
+++ b/integration_test/viss/features/viss_v3_core_read.feature
@@ -1,0 +1,62 @@
+#
+# https://raw.githack.com/COVESA/vehicle-information-service-specification/main/spec/VISSv3.0_Core.html
+#
+
+Feature: VISS v3 Compliance Testing - Core operations
+
+  Background:
+    Given the VISS server is running
+    Given the VISS client is connected via WebSocket
+
+  # 5.1.1 Read
+  # Purpose: Get one or more values addressed by the given path.
+  @MustHave
+  Scenario: Read a valid data path
+    When I send a read request with path "Vehicle.Speed"
+    Then I should receive a valid read response
+
+  # 5.1.3 Subscribe request
+  # The VISS server must support subscriptions to receive data updates.
+  @MustHave
+  Scenario: Subscribe to a data path
+    When I send a subscription request for "Vehicle.Speed"
+    Then I should receive a valid subscribe response
+
+  # 5.1.3 Subscribe request - Error handling
+  # The VISS server must return an error when subscribing to an invalid data path.
+  @MustHave
+  Scenario: Subscribe to an unknown data path
+    When I send a subscription request for "Some.Unknown.Datapoint"
+    Then I should receive a subscribe error event
+
+  # 5.1.3 Subscribe request & 5.1.4 Set request
+  # The VISS server must notify subscribers of data updates and enforce read-only restrictions.
+  @MustHave
+  Scenario: Subscribe and update a data path
+    When I send a subscription request for "Vehicle.Speed"
+    Then I should receive a valid subscribe response
+    When I send a set request for path "Vehicle.Speed" with the value 123
+    Then I should receive a valid subscription event
+    Then I should receive a read-only error
+
+  # 5.1.3 Subscribe request - Unsubscribe
+  # The VISS server must support unsubscribing from an existing subscription.
+  @MustHave
+  Scenario: Subscribe and Unsubscribe
+    Given I have a subscription to "Vehicle.Speed"
+    When I send an unsubscribe request
+    Then I should receive a valid unsubscribe response
+
+  # 5.1.4 Set request - Read-only restriction
+  # The VISS server must reject set requests to read-only signals.
+  @MustHave
+  Scenario: Setting a read-only signal (sensor)
+    When I send a set request for path "Vehicle.Speed" with the value 80
+    Then I should receive a read-only error
+
+  # 5.1.4 Set request - Writing to actuators
+  # The VISS server must allow set requests to writable signals (actuators).
+  @MustHave
+  Scenario: Setting a writable signal (actuator)
+    When I send a set request for path "Vehicle.Cabin.Infotainment.HMI.FontSize" with the value LARGE
+    Then I should receive a valid set response

--- a/integration_test/viss/features/viss_v3_transport_grpc.feature
+++ b/integration_test/viss/features/viss_v3_transport_grpc.feature
@@ -1,0 +1,16 @@
+#
+# https://raw.githack.com/COVESA/vehicle-information-service-specification/main/spec/VISSv3.0_Core.html
+#
+
+Feature: VISS v3 Compliance Testing - Transport: gRPC
+
+  Background:
+    Given the VISS server is running
+    Given the VISS client is connected via gRPC
+
+  # 5.1.1 Read
+  # Purpose: Get one or more values addressed by the given path.
+  @MustHave
+  Scenario: Read a valid data path
+    When I send a read request with path "Vehicle.Speed"
+    Then I should receive a valid read response

--- a/integration_test/viss/features/viss_v3_transport_http.feature
+++ b/integration_test/viss/features/viss_v3_transport_http.feature
@@ -1,0 +1,16 @@
+#
+# https://raw.githack.com/COVESA/vehicle-information-service-specification/main/spec/VISSv3.0_Core.html
+#
+
+Feature: VISS v3 Compliance Testing - Transport: HTTP
+
+  Background:
+    Given the VISS server is running
+    Given the VISS client is connected via HTTP
+
+  # 5.1.1 Read
+  # Purpose: Get one or more values addressed by the given path.
+  @MustHave
+  Scenario: Read a valid data path
+    When I send a read request with path "Vehicle.Speed"
+    Then I should receive a valid read response

--- a/integration_test/viss/features/viss_v3_transport_mqtt.feature
+++ b/integration_test/viss/features/viss_v3_transport_mqtt.feature
@@ -1,0 +1,16 @@
+#
+# https://raw.githack.com/COVESA/vehicle-information-service-specification/main/spec/VISSv3.0_Core.html
+#
+
+Feature: VISS v3 Compliance Testing - Transport: MQTT
+
+  Background:
+    Given the VISS server is running
+    Given the VISS client is connected via MQTT
+
+  # 5.1.1 Read
+  # Purpose: Get one or more values addressed by the given path.
+  @MustHave
+  Scenario: Read a valid data path
+    When I send a read request with path "Vehicle.Speed"
+    Then I should receive a valid read response

--- a/integration_test/viss/features/viss_v3_transport_wss.feature
+++ b/integration_test/viss/features/viss_v3_transport_wss.feature
@@ -1,0 +1,16 @@
+#
+# https://raw.githack.com/COVESA/vehicle-information-service-specification/main/spec/VISSv3.0_Core.html
+#
+
+Feature: VISS v3 Compliance Testing - Transport: WebSocket
+
+  Background:
+    Given the VISS server is running
+    Given the VISS client is connected via WebSocket
+
+  # 5.1.1 Read
+  # Purpose: Get one or more values addressed by the given path.
+  @MustHave
+  Scenario: Read a valid data path
+    When I send a read request with path "Vehicle.Speed"
+    Then I should receive a valid read response

--- a/integration_test/viss/mosquitto-config/mosquitto.conf
+++ b/integration_test/viss/mosquitto-config/mosquitto.conf
@@ -1,0 +1,20 @@
+# https://mosquitto.org/man/mosquitto-conf-5.html
+
+# Bind to all network interfaces on port 1883
+# Makes it easy to connect via docker
+listener 1883
+
+# Allow all clients to connect, since we run in docker
+allow_anonymous true
+
+# info, debug etc.
+#log_dest stdout
+#log_type debug
+log_type error
+log_type notice
+log_type information
+log_type debug
+log_type websockets
+log_timestamp_format %Y-%m-%dT%H:%M:%S
+connection_messages true
+log_dest stdout

--- a/integration_test/viss/pytest.ini
+++ b/integration_test/viss/pytest.ini
@@ -1,0 +1,21 @@
+[pytest]
+markers =
+    MustHave: Kuksa: A mandatory requirement to be VISSv2 compliant.
+    ShouldHave: Kuksa: An optional requirement to be VISSv2 compliant.
+    Proprietary: Kuksa: An unspecified, proprietary feature.
+
+addopts = --alluredir allure-results
+          --clean-alluredir
+          --strict-config
+          --strict-markers
+
+required_plugins = pytest-bdd
+
+testpaths = "tests"
+bdd_features_base_dir = "features"
+
+viss_ws_base_url = ws://localhost:8090
+viss_http_base_url = http://localhost:8090
+viss_mqtt_base_url = mqtt://localhost:1883
+viss_connect_timeout = 1.0
+viss_message_timeout = 0.1

--- a/integration_test/viss/readme.md
+++ b/integration_test/viss/readme.md
@@ -1,0 +1,122 @@
+# Kuksa VISS Server Specification Compliance Testing
+
+## Test Framework Architecture
+
+- pytest-bdd for Gherkin-based testing.
+- reusable step definitions for HTTP, WebSockets, and MQTT interactions.
+- tests structured in a modular way to allow easy extension for VISS v3.
+- reports generated with allure-pytest to assess compliance.
+
+## Pre-Requisites
+
+- Python 3
+- Databroker
+- VSS Release 4.0
+- Optional: MQTT broker for testing MQTT transport protocol
+- kuksa-common for `jwt.key.pub` to test Authorization / Access Control
+
+### Enable VISS feature
+
+Build databroker with the `viss` feature enabled:
+
+```
+cargo build --bin databroker --features viss --release
+```
+
+### Dependencies
+
+The integration tests require additional Python libraries to be installed:
+
+```
+cd integration_test/viss/
+python -m venv .venv
+source .venv/bin/activate
+
+pip install pytest pytest-bdd allure-pytest-bdd requests websocket-client paho-mqtt tinydb
+```
+
+## Running the tests
+
+Start databroker from project root:
+```
+RUST_LOG=debug cargo run --bin databroker --release --features viss -- --vss data/vss-core/vss_release_4.0.json --insecure --enable-viss --viss-address 0.0.0.0 --viss-port 8090
+```
+
+> RUST_LOG=debug enables debug log messages of databroker, which shows incoming and outgoing VISS requests and makes it easier to troubleshoot failing tests.
+
+Execute the test suite
+```
+# Just run all tests in ./integration_test/viss
+pytest
+```
+
+### Troubleshooting tests
+
+Debugging the tests: run `pytest` with additional arguments to disable capturing the output and to enable debug log level:
+```
+# Run all tests and show test-code log messages, e.g. outgoing client requests
+pytest -s -v --log-level=DEBUG
+
+# Only run tests which have the "@MustHave" marker:
+pytest -m MustHave
+
+# Run only specific tests using the keyword option, e.g. 'basic' or 'http' etc.
+pytest -k 'basic'
+```
+
+## MQTT Setup (optional)
+
+Run mqtt broker:
+```
+# Run in integration_test/viss:
+
+docker run -it -p 1883:1883 -v "$PWD/mosquitto-config:/mosquitto/config" eclipse-mosquitto
+```
+
+## Authorization
+
+_Setup:_ Clone kuksa-common for pre-built JWT tokens for testing purposes.
+
+Start databroker with public key using `--jwt-public-key` to enable validation of access tokens:
+
+```
+RUST_LOG=debug cargo run --bin databroker --release --features viss -- --vss data/vss-core/vss_release_4.0.json --insecure --enable-databroker-v1 --enable-viss --viss-address 0.0.0.0 --viss-port 8090 --jwt-public-key kuksa-common/jwt/jwt.key.pub
+```
+
+Re-run tests:
+```
+```
+
+## Test Reports
+
+### Pre-Requisites
+
+We use Allure Report to produce test results reports: https://allurereport.org/docs/pytest/
+
+- Install Allure Report, see https://allurereport.org/docs/install-for-linux/
+- Requires Java Runtime
+
+```
+sudo apt-get update
+sudo apt-get install default-jre
+wget https://github.com/allure-framework/allure2/releases/download/2.33.0/allure_2.33.0-1_all.deb
+sudo dpkg -i allure_<version>_all.deb
+```
+
+### Run the tests to generate reports
+
+```
+pytest --alluredir allure-results
+```
+
+### Test Report User Interface
+
+Start web server:
+```
+allure serve allure-results
+```
+
+Open browser (Note: port may have changed):
+```
+http://127.0.0.1:37541
+```

--- a/integration_test/viss/requirements.txt
+++ b/integration_test/viss/requirements.txt
@@ -1,0 +1,11 @@
+asyncio
+grpcio
+protobuf
+pytest
+pytest-ordering
+pytest-bdd
+allure-pytest-bdd
+requests
+websocket-client
+paho-mqtt
+tinydb

--- a/integration_test/viss/tests/test_steps/http_viss_client.py
+++ b/integration_test/viss/tests/test_steps/http_viss_client.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# /********************************************************************************
+# * Copyright (c) 2025 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+import json
+import requests
+import logging
+import time
+import pytest
+from tinydb import TinyDB, Query, where
+from tinydb.storages import MemoryStorage
+from .types import RequestId
+logger = logging.getLogger(__name__)
+
+class HttpVISSClient:
+
+    def __init__(self,pytestconfig):
+        self.pytestconfig = pytestconfig
+        self.received_messages = TinyDB()
+        self.sent_messages = TinyDB()
+        self._client_is_connected = False
+
+    def is_connected(self)-> bool:
+        return self._client_is_connected
+
+    def connect(self):
+        self._client_is_connected = True
+
+    def disconnect(self):
+        self._client_is_connected = False
+
+    def send(self, request_id, message, authorization):
+        path = message["path"]
+        uripath=path.replace('.','/')
+
+        baseurl = self.pytestconfig.getini('viss_http_base_url')
+        timeout=float(self.pytestconfig.getini('viss_connect_timeout'))
+
+        headers={}
+        if authorization:
+            logger.debug("Injecting authorization token to HTTP request")
+            headers["Authorization"] = f"Bearer {authorization["token"]}"
+
+        if "get" == message['action']:
+            response = requests.get(f"{baseurl}/{uripath}",timeout=timeout,headers=headers)
+        else:
+            pytest.exit('unimplemented test code')
+        logger.debug(f"HTTP Response: {response}")
+
+        envelope_sent = {
+                    "timestamp": time.time(),
+                    "protocol": "http",
+                    "requestId": request_id.current(),
+                    "action": message['action'],
+                    "body": message
+        }
+        logger.debug(f"HTTP Envelope sent: {envelope_sent}")
+
+        envelope_received = {
+                    "timestamp": time.time(),
+                    "protocol": "http",
+                    "requestId": request_id.current(),
+                    "action": message['action'],
+                    "body": json.loads(response.content)
+        }
+        if response.status_code != 200:
+            envelope_received['error'] = {
+                "number": response.status_code,
+                "reason": response.reason,
+                "message": response.content
+            }
+        logger.debug(f"HTTP Envelope received: {envelope_received}")
+
+        self.sent_messages.insert(envelope_sent)
+        self.received_messages.insert(envelope_received)
+
+    def find_messages(self, *,
+                      subscription_id : str = None,
+                      request_id : RequestId = None,
+                      action : str = None,
+                      authorization = None):
+        if subscription_id and not isinstance(subscription_id, str):
+            raise TypeError(f"subscription_id must be str, not {type(subscription_id)}")
+        if request_id and not isinstance(request_id, RequestId):
+            raise TypeError(f"request_id must be RequestId, not {type(request_id)}")
+
+        # Initialize a list to hold conditions
+        conditions = []
+
+        if subscription_id:
+            logger.debug(f"Adding search condition subscriptionId={subscription_id}")
+            conditions.append(where('subscriptionId') == subscription_id)
+        if request_id:
+            logger.debug(f"Adding search condition requestId={request_id.current()}")
+            conditions.append(where('requestId') == request_id.current())
+        if action:
+            logger.debug(f"Adding search condition action={action}")
+            conditions.append(where('action') == action)
+
+        search_template = Query()
+        # Combine conditions using AND if there are any
+        if conditions:
+            search_template = conditions[0]  # Start with the first condition
+            for condition in conditions[1:]:
+                search_template &= condition  # Combine with AND
+
+        logger.debug(f"Query template: {search_template}")
+        results = self.received_messages.search(search_template)
+        logger.debug(f"Found messages: {results}")
+        # TODO: "results" is a list of "envelop", but we need to return a list of the message bodies?
+        return results
+
+    def find_message(self, *,
+                     subscription_id=None,
+                     request_id=None,
+                     action=None,
+                     authorization=None):
+        results = self.find_messages(subscription_id=subscription_id,
+                                     request_id=request_id,
+                                     action=action,
+                                     authorization=authorization)
+        result = max(results,key=lambda x: x["timestamp"], default=None)
+        logger.debug(f"Found latest message: {result}")
+        return result

--- a/integration_test/viss/tests/test_steps/mqtt_mock_databroker.py
+++ b/integration_test/viss/tests/test_steps/mqtt_mock_databroker.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# /********************************************************************************
+# * Copyright (c) 2025 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+import time
+import json
+import logging
+import paho.mqtt.client
+from paho.mqtt.subscribeoptions import SubscribeOptions
+import urllib
+import random
+
+logger = logging.getLogger(__name__)
+
+class MQTTVISSServerMock:
+
+    def __init__(self,pytestconfig):
+        self.pytestconfig = pytestconfig
+        self._is_subscribed = False
+
+    def on_subscribe(self, client, userdata, mid, reason_code_list, properties):
+        self._is_subscribed = True
+
+    def on_unsubscribe(self, client, userdata, mid, reason_code_list, properties):
+        self._is_subscribed = False
+
+    def on_connect(self, client, userdata, flags, reason_code, properties):
+        logger.debug("on_connect")
+        # Prevent receiving our own messages
+        options = SubscribeOptions(qos=0, noLocal=True)
+        self.mqttc.subscribe("VID/Vehicle", options=options)
+
+    def on_message(self, client, userdata, message):
+        logger.debug(f"on_message: {message.payload}")
+        logger.debug(f"client: {client}")
+        parsed = json.loads(message.payload)
+        logger.debug(f"parsed: {parsed}")
+        if (parsed['action'] == "get"):
+            if "path" in parsed:
+                logger.debug("Has path")
+                if parsed['path'].startswith("Vehicle."):
+                    logger.debug("Starts with Vehicle")
+                    reply={
+                        "action": "get",
+                        "requestId": parsed['requestId'],
+                        "data": {
+                            "path": parsed['path'],
+                            "dp": {
+                                "value":"2372",
+                                "ts": "2020-04-15T13:37:00Z"
+                                }
+                            }
+                    }
+                else:
+                    reply={
+                        "action": "get",
+                        "requestId": parsed['requestId'],
+                        "error": {"number": 404, "reason": "invalid_path", "message": "The requested data was not found."},
+                        "ts": "2020-04-15T13:37:00Z"
+                    }
+
+                topic="VID/Vehicle"
+                logger.debug(f"publish: topic={topic} payload={reply}")
+                info=self.mqttc.publish(topic=topic,
+                            payload=json.dumps(reply))
+                info.wait_for_publish(timeout=1.0)
+                logger.debug(f"published")
+            else:
+                logger.debug("Message seems to be from ourselves, ignoring.")
+                pass
+        else:
+            raise ValueError(f"Unknown action: {parsed['action']}")
+
+    def connect(self):
+        client_id=f"mockserver-{random.randint(0, 100000)}"
+        logger.debug(f"connect {client_id}")
+        self._mockserver_is_connected = True
+        self.mqttc = paho.mqtt.client.Client(callback_api_version=paho.mqtt.client.CallbackAPIVersion.VERSION2,
+                                 protocol=paho.mqtt.client.MQTTv5,
+                                 client_id=client_id)
+        self.mqttc.enable_logger()
+        self.mqttc.reconnect_delay_set(1,1)
+        self.mqttc.on_connect = self.on_connect
+        self.mqttc.on_message = self.on_message
+        baseurl = urllib.parse.urlparse(self.pytestconfig.getini("viss_mqtt_base_url"))
+        self.mqttc.connect(host=baseurl.hostname,
+                           port=baseurl.port,
+                           keepalive=60)
+        self.mqttc.loop_start()
+        while not self.mqttc.is_connected():
+            time.sleep(0.1)
+
+    def disconnect(self):
+        logger.debug("disconnect")
+        self._mockserver_is_connected = False
+        self.mqttc.unsubscribe("VID/Vehicle")
+        self.mqttc.disconnect()

--- a/integration_test/viss/tests/test_steps/mqtt_viss_client.py
+++ b/integration_test/viss/tests/test_steps/mqtt_viss_client.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# /********************************************************************************
+# * Copyright (c) 2025 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+import time
+import json
+import logging
+import paho.mqtt.client
+from paho.mqtt.subscribeoptions import SubscribeOptions
+import urllib
+import random
+
+from tinydb import TinyDB, Query, where
+from tinydb.storages import MemoryStorage
+from .types import RequestId
+from .mqtt_mock_databroker import MQTTVISSServerMock
+
+TinyDB.default_storage_class = MemoryStorage
+logger = logging.getLogger(__name__)
+
+class MQTTVISSClient:
+
+    def __init__(self,pytestconfig):
+        self.pytestconfig = pytestconfig
+        self.received_messages = TinyDB()
+        self.sent_messages = TinyDB()
+        self._prevent_my_own_messages = set()
+        self._client_is_connected = False
+        self._is_subscribed = False
+
+    def is_connected(self)-> bool:
+        return self._client_is_connected
+
+    def on_subscribe(self, client, userdata, mid, reason_code_list, properties):
+        logger.debug("on_subscribe")
+        self._is_subscribed = True
+
+    def on_unsubscribe(self, client, userdata, mid, reason_code_list, properties):
+        logger.debug("on_unsubscribe")
+        self._is_subscribed = False
+
+    def on_connect(self, client, userdata, flags, reason_code, properties):
+        logger.debug("on_connect start")
+        options = SubscribeOptions(qos=0, noLocal=True)
+        self.mqttc.subscribe("VID/Vehicle", options=options)
+        logger.debug("on_connect end")
+
+    def on_message(self, client, userdata, message):
+        logger.debug(f"on_message: {message.payload}")
+        if message.payload in self._prevent_my_own_messages:
+            logger.debug(f"Ignoring my own message: {message.payload}")
+            return
+
+        body = json.loads(message.payload)
+        envelope = {
+            "protocol": "mqtt",
+            "timestamp": time.time(),
+            "body": body
+        }
+
+        if "requestId" in body:
+            envelope['requestId'] = body['requestId']
+        if "subscriptionId" in body:
+            envelope['subscriptionId'] = body['subscriptionId']
+        if "action" in body:
+            envelope['action'] = body['action']
+
+        self.received_messages.insert(envelope)
+
+    def connect(self):
+        logger.debug("connect")
+        self._client_is_connected = True
+
+        # TODO: Replace mock with real databroker
+        # TODO: Remove
+        self.servermock = MQTTVISSServerMock(self.pytestconfig)
+        self.servermock.connect()
+
+        self.mqttc = paho.mqtt.client.Client(callback_api_version=paho.mqtt.client.CallbackAPIVersion.VERSION2,
+                                 protocol=paho.mqtt.client.MQTTv5,
+                                 client_id=f"viss-client-{random.randint(0, 100000)}")
+        self.mqttc.enable_logger()
+        self.mqttc.reconnect_delay_set(1,1)
+        self.mqttc.on_connect = self.on_connect
+        self.mqttc.on_message = self.on_message
+        baseurl = urllib.parse.urlparse(self.pytestconfig.getini("viss_mqtt_base_url"))
+        self.mqttc.connect(host=baseurl.hostname,
+                           port=baseurl.port,
+                           keepalive=60)
+        self.mqttc.loop_start()
+        while not self.mqttc.is_connected():
+            time.sleep(0.1)
+
+    def disconnect(self):
+        logger.debug("disconnect")
+        self._client_is_connected = False
+        self.mqttc.unsubscribe("VID/Vehicle")
+        self.mqttc.disconnect()
+
+        # TODO: Replace mock with real databroker
+        # TODO: Remove
+        self.servermock.disconnect()
+
+    def send(self,request_id,message,authorization):
+        topic="VID/Vehicle"
+        if "authorization" in authorization:
+            logger.debug("Injecting authorization into MQTT payload")
+            message["authorization"] = authorization["token"]
+        payload=json.dumps(message)
+        info = self.mqttc.publish(topic=topic,
+                                payload=payload)
+        self._prevent_my_own_messages.add(payload)
+        info.wait_for_publish(timeout=1.0)
+        logger.debug(f"publish: topic={topic} payload={message}")
+        envelope = {
+            "protocol": "mqtt",
+            "timestamp": time.time(),
+            "action": message['action'],
+            "requestId": request_id.current(),
+            "body": message
+        }
+        logger.debug(f"Storing sent envelope: {envelope}")
+        self.sent_messages.insert(envelope)
+
+    def retry_until_condition_met(self, condition_lambda, task_lambda, interval=0.1, timeout=2):
+        start_time = time.time()
+        while True:
+            # Execute the task
+            result = task_lambda()
+
+            # Check if the condition is met
+            if condition_lambda(result):
+                return result
+
+            # Check for timeout
+            elapsed_time = time.time() - start_time
+            if elapsed_time >= timeout:
+                logger.debug("Timeout reached. Aborting.")
+                return None
+
+            # Wait for the specified interval before retrying
+            time.sleep(interval)
+            logger.debug("Retrying task...")
+
+    def find_subscription_id_by_request_id(self, request_id):
+        logger.debug(f"Searching received messages for the subscriptionId with requestId={request_id.current()}")
+        search_template = Query()
+        query = (search_template.requestId == request_id.current()) & (search_template.action == 'subscribe')
+        condition = lambda result: result is not None and len(result)>0
+        search = lambda: max(self.received_messages.search(query), key=lambda x: x["timestamp"], default=None)
+        result = self.retry_until_condition_met(condition,search)
+
+        if result:
+            if "subscriptionId" in result:
+                return result['subscriptionId']
+        # Allow invalid subscriptions, eg to test for error situations
+        # where no subscription is actually created
+        return None
+
+
+    def find_messages(self, *,
+                      subscription_id : str = None,
+                      request_id : RequestId = None,
+                      action : str = None,
+                      authorization = None):
+        # Initialize a list to hold conditions
+        logger.debug("Find messages...")
+        conditions = []
+        if subscription_id:
+            logger.debug(f"Adding search condition subscriptionId={subscription_id}")
+            conditions.append(where('subscriptionId') == subscription_id)
+        if request_id:
+            logger.debug(f"Adding search condition requestId={request_id.current()}")
+            conditions.append(where('requestId') == request_id.current())
+        if action:
+            logger.debug(f"Adding search condition action={action}")
+            conditions.append(where('action') == action)
+
+        search_template = Query()
+        # Combine conditions using AND if there are any
+        if conditions:
+            search_template = conditions[0]  # Start with the first condition
+            for condition in conditions[1:]:
+                search_template &= condition  # Combine with AND
+
+        logger.debug(f"Query template: {search_template}")
+
+        condition = lambda result: result is not None and len(result)>0
+        task = lambda: self.received_messages.search(search_template)
+        results = self.retry_until_condition_met(condition, task)
+
+        logger.debug(f"Found messages: {results}")
+        # TODO: "results" is a list of "envelop", but we need to return a list of the message bodies?
+        return results
+
+    def find_message(self, *,
+                     subscription_id=None,
+                     request_id=None,
+                     action=None,
+                     authorization=None):
+        logger.debug("Find message...")
+        results = self.find_messages(subscription_id=subscription_id,
+                                     request_id=request_id,
+                                     action=action,
+                                     authorization=authorization)
+        result = max(results,key=lambda x: x["timestamp"], default=None)
+        logger.debug(f"Found latest message: {result}")
+        return result

--- a/integration_test/viss/tests/test_steps/types.py
+++ b/integration_test/viss/tests/test_steps/types.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# /********************************************************************************
+# * Copyright (c) 2025 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+import uuid
+
+# A mutable request_id
+class RequestId:
+    _current_request_id : str
+    def __init__(self):
+        self._current_request_id=str(uuid.uuid4())
+    def new(self) -> str:
+        self._current_request_id=str(uuid.uuid4())
+        return self._current_request_id
+    def current(self) -> str:
+        return self._current_request_id

--- a/integration_test/viss/tests/test_steps/viss_v2_steps.py
+++ b/integration_test/viss/tests/test_steps/viss_v2_steps.py
@@ -1,0 +1,714 @@
+#!/usr/bin/env python3
+# /********************************************************************************
+# * Copyright (c) 2025 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+import logging
+import requests
+import pytest
+from pytest_bdd import given, when, then,parsers
+
+from .http_viss_client import HttpVISSClient
+from .mqtt_viss_client import MQTTVISSClient
+from .websockets_viss_client import WebSocketsVISSClient
+from .types import RequestId
+
+# Basic logging
+logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+class ConnectedClients():
+
+    def __init__(self,pytestconfig):
+        self.pytestconfig=pytestconfig
+        self.clients = {
+            'HTTP': HttpVISSClient(pytestconfig),
+            'MQTT': MQTTVISSClient(pytestconfig),
+            'WebSockets': WebSocketsVISSClient(pytestconfig)
+        }
+        logger.debug("Creating new ConnectedClients")
+        pass
+
+    def httpclient(self):
+        return self.clients['HTTP']
+
+    def wsclient(self):
+        return self.clients['WebSockets']
+
+    def mqttclient(self):
+        return self.clients['MQTT']
+
+    def connect(self):
+        logger.debug(f"Connecting clients...")
+        for key,client in self.clients.items():
+            if not client.is_connected():
+                logger.debug(f"Connecting client: {key}")
+                client.connect()
+
+    def disconnect(self):
+        logger.debug(f"Disconnecting connected clients...")
+        for key,client in self.clients.items():
+            if client.is_connected():
+                logger.debug(f"Disconnecting client: {key}")
+                client.disconnect()
+
+    def send(self, request_id,message,authorization=None):
+        for key,client in self.clients.items():
+            if client.is_connected():
+                client.send(request_id,message,authorization)
+                logger.debug(f"Sent message: {message}")
+
+    def find_subscription_id_by_request_id(self, request_id):
+        # TODO: Last one wins
+        for key,client in self.clients.items():
+            if client.is_connected():
+                response=client.find_subscription_id_by_request_id(request_id=request_id,)
+                logger.debug(f"Found message: {response}")
+        return response
+
+    def find_message(self, *,
+                     subscription_id=None,
+                     request_id=None,
+                     action=None,
+                     authorization=None):
+        for key,client in self.clients.items():
+            if client.is_connected():
+                response=client.find_message(subscription_id=subscription_id,
+                                             request_id=request_id,
+                                             action=action,
+                                             authorization=authorization)
+                logger.debug(f"Found message: {response}")
+        # TODO: Last one wins
+        return response
+
+    def find_messages(self, *,
+                      subscription_id : str = None,
+                      request_id : RequestId = None,
+                      action : str = None,
+                      authorization = None):
+        for key,client in self.clients.items():
+            if client.is_connected():
+                response=client.find_messages(subscription_id=subscription_id,
+                                              request_id=request_id,
+                                              action=action,
+                                              authorization=authorization)
+                logger.debug(f"Found message: {response}")
+        return response
+
+
+@pytest.fixture
+def request_id():
+    return RequestId()
+
+@pytest.fixture
+def connected_clients(request,pytestconfig):
+    connected_clients = ConnectedClients(pytestconfig)
+    def cleanup():
+        connected_clients.disconnect()
+    request.addfinalizer(cleanup)
+    return connected_clients
+
+@pytest.fixture
+def http_client(connected_clients):
+    return connected_clients.clients['HTTP']
+
+@pytest.fixture
+def ws_client(connected_clients):
+    return connected_clients.clients['WebSockets']
+
+@pytest.fixture
+def mqtt_client(connected_clients):
+    return connected_clients.clients['MQTT']
+
+@pytest.fixture
+def mqtt_client(connected_clients):
+    return connected_clients.clients['MQTT']
+
+@pytest.fixture
+def authorization():
+    empty_authorization = {}
+    return empty_authorization
+
+@given("I am authorized", target_fixture="authorization")
+def given_authorized(authorization):
+    return given_authorized_vsspath(authorization, "Vehicle.Speed")
+
+@given(parsers.parse("I am authorized to read \"{path}\""), target_fixture="authorization")
+def given_authorized_vsspath(authorization,path):
+    # TODO: This token is only for Vehicle.Speed
+    if "Vehicle.Speed" != path:
+        raise NameError("Authorizing for other VSS paths than Vehicle.Speed not yet supported.")
+    authorization={
+        "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJsb2NhbCBkZXYiLCJpc3MiOiJjcmVhdGVUb2tlbi5weSIsImF1ZCI6WyJrdWtzYS52YWwiXSwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3NjcyMjU1OTksInNjb3BlIjoicHJvdmlkZTpWZWhpY2xlLlNwZWVkIn0.WlHkTSverOeprozFHG5Oo14c_Qr0NL9jv3ObAK4S10ddbqFRjWttkY9C0ehLqM6vXNUyI9uimbrM5FSPpw058mWGbOaEc8l1ImjS-DBKkDXyFkSlMoCPuWfhbamfFWTfY-K_K21kTs0hvr-FGRREC1znnZx0TFEi9HQO2YJvsSfJ7-6yo1Wfplvhf3NCa-sC5PrZEEbvYLkTB56C--0waqxkLZGx_SAo_XoRCijJ3s_LnrEbp61kT9CVYmNk017--mA9EEcjpHceOOtj1_UVjHpLKHOxitjpF-7LQNdq2kCY-Y2qv9vf8H6nAFVG8QKAUAaFb0CmYpDIdK8XSLRD7yLd6JnoRswBqmveFCUpmdrMYsSgut1JH4oCn5EnJ-c5UfZ4IRDgc7iBE5cqH9ao7j5PItsE9tYQJDAfygel3sYnIzuAd-DMYyPs1Jj9BzrAWEmI9s0PelA0KAEspmNufn9e-mjeC050e5NhhzJ4Vj_ffbOBzgx1vgLAaoMj5dOb4j3OpNC0XoUgGfR-YbTLi48h6uXEnxsXNGblOlSqTBmy2iZhYpfLBIsdvQTzKf2iYkw_TLo5LE5p9m4aUKFywcyGPMxzVcA8JIJ2g2Xp30RnIAxUlDTXcuYDGYRgKiGJb0rq1yQVl3RCnKaxTVHg8qqHkts_B-cbItlZP8bJA5M"
+    }
+    return authorization
+
+
+@pytest.fixture(scope='session')
+def server(pytestconfig):
+    """Run the server subprocess and handle its stdout."""
+    url = pytestconfig.getini("viss_http_base_url")
+    try:
+        requests.get(url, timeout=float(pytestconfig.getini("viss_connect_timeout")))
+    except requests.exceptions.ConnectionError:
+        logger.error("Databroker not running, exiting...")
+        pytest.exit(f"FATAL: Databroker not running at {url}")
+
+@pytest.fixture(scope='session')
+def secured_server(pytestconfig,command):
+    """Run the server subprocess and handle its stdout."""
+    url = pytestconfig.getini("viss_http_base_url")
+    try:
+        requests.get(url, timeout=float(pytestconfig.getini("viss_connect_timeout")))
+    except requests.exceptions.ConnectionError:
+        logger.error("Databroker not running, exiting...")
+        pytest.exit(f"FATAL: Databroker not running at {url}")
+
+
+@given("the VISS server is running")
+def viss_server_running(pytestconfig, server):
+    # Just ensure the server is running
+    pass
+
+@given("the secured VISS server is running")
+def viss_server_running_secured(pytestconfig, secured_server):
+    # Just ensure the server is running
+    pass
+
+@given("the VISS client is connected via HTTP")
+def viss_client_connected_via_http(http_client):
+    logger.debug("Connecting via HTTP")
+    http_client.connect()
+
+@given("the VISS client is connected via WebSocket")
+def viss_client_connected_via_websocket(ws_client):
+    logger.debug("Connecting via WebSocket")
+    ws_client.connect()
+
+@given("the VISS client is connected via MQTT")
+def viss_client_connected_via_mqtt(mqtt_client):
+    logger.debug("Connecting via MQTT")
+    mqtt_client.connect()
+
+@given(parsers.parse("I have a subscription to \"{path}\""), target_fixture="subscription_id")
+@when(parsers.parse('I send a subscription request for "{path}"'), target_fixture="subscription_id")
+def send_subscribe(connected_clients, request_id, path):
+    request = {"action": "subscribe", "path": path, "requestId": request_id.new()}
+    connected_clients.send(request_id, request)
+    return connected_clients.find_subscription_id_by_request_id(request_id)
+
+@when(parsers.parse('I subscribe to "{path}" using a curvelog filter with maxerr {maxerr} and bufsize {bufsize}'), target_fixture="subscription_id")
+def subscribe_filter_curvelog(connected_clients, request_id, path, maxerr, bufsize):
+    request = {
+        "action": "subscribe",
+        "path": path,
+        "filter": {
+            "type":"curvelog",
+            "parameter": {
+                    "maxerr": maxerr,
+                    "bufsize": bufsize
+                }
+        }
+        ,
+        "requestId": request_id.new()
+    }
+    connected_clients.send(request_id, request)
+    return connected_clients.find_subscription_id_by_request_id(request_id)
+
+@when(parsers.parse('I send an unsubscribe request'))
+def send_ws_unsubscribe(connected_clients, request_id, subscription_id):
+    request = {"action": "unsubscribe", "subscriptionId": subscription_id, "requestId": request_id.new()}
+    connected_clients.send(request_id, request)
+
+@when(parsers.parse('I send a read request with path "{path}"'))
+def send_read_data_point(connected_clients, request_id, path, authorization):
+    request = {"action": "get", "path": path, "requestId": request_id.new()}
+    connected_clients.send(request_id, request, authorization)
+
+@when(parsers.parse('I search "{path}" using a path filter "{filter}"'))
+def search_path_filter(connected_clients,request_id,  path, filter, authorization):
+    request = {
+        "action": "get",
+        "path": path,
+        "filter" : {
+            "type": "paths",
+            "parameter" : [
+                filter
+            ]
+        },
+        "requestId": request_id.new()
+    }
+    connected_clients.send(request_id, request)
+
+@when(parsers.parse('I search "{path}" using a history filter "{filter}"'))
+def search_history_filter(connected_clients,request_id, path, filter):
+    request = {
+        "action": "get",
+        "path": path,
+        "filter" : {
+            "type": "history",
+            "parameter": filter
+        },
+        "requestId": request_id.new()
+    }
+    connected_clients.send(request_id, request)
+
+@when(parsers.parse('I search "{path}" using a dynamic metadata filter "{filter}"'))
+def search_dynamic_metadata_filter(connected_clients, request_id, path, filter):
+    request = {
+        "action": "get",
+        "path": path,
+        "filter" : {
+            "type": "dynamic-metadata",
+            "parameter": [
+                 filter
+            ]
+        },
+        "requestId": request_id.new()
+    }
+    connected_clients.send(request_id, request)
+
+@when(parsers.parse('I search "{path}" using a static metadata filter "{filter}"'))
+def search_static_metadata_filter(connected_clients, request_id, path, filter):
+    request = {
+        "action": "get",
+        "path": path,
+        "filter" : {
+            "type": "static-metadata",
+            "parameter": [
+                filter
+            ]
+        },
+        "requestId": request_id.new()
+    }
+    connected_clients.send(request_id, request)
+
+@when(parsers.parse('I subscribe to "{path}" using a range filter'), target_fixture="subscription_id")
+def search_static_range_filter(connected_clients,request_id, path):
+    request = {
+        "action": "subscribe",
+        "path": path,
+        "filter" : {
+            "type": "range",
+            "parameter":
+                [
+                    {
+                        "boundary-op":"lt",
+                        "boundary":"50",
+                        "combination-op":"OR"
+                    },
+                    {
+                        "boundary-op":"gt",
+                        "boundary":"55"
+                    }
+                ]
+        },
+        "requestId": request_id.new()
+    }
+    connected_clients.send(request_id, request)
+    return connected_clients.find_subscription_id_by_request_id(request_id)
+
+@when(parsers.parse('I subscribe to "{path}" using a change filter'), target_fixture="subscription_id")
+def search_static_change_filter(connected_clients,request_id,  path):
+    request = {
+        "action": "subscribe",
+        "path": path,
+        "filter" : {
+            "type": "change",
+            "parameter": {
+                   "logic-op":"gt",
+                   "diff":"10"
+            }
+        },
+        "requestId": request_id.new()
+    }
+    connected_clients.send(request_id, request)
+    return connected_clients.find_subscription_id_by_request_id(request_id)
+
+@when(parsers.parse('I send a set request for path "{path}" with the value {value}'))
+def send_set(connected_clients, request_id, path, value):
+    request = {"action": "set", "path": path, "requestId": request_id.new(), "value": value}
+    connected_clients.send(request_id, request)
+
+@then("I should receive a valid read response")
+def receive_valid_get_response(connected_clients, request_id):
+    envelope = connected_clients.find_message(request_id=request_id,
+                                              action="get")
+    response = envelope["body"]
+    assert "data" in response
+
+    # HTTP response messages do not contain "action" or "requestId"
+    if envelope["protocol"] != "http":
+        assert "action" in response
+        assert "requestId" in response
+
+    assert "error" not in response
+
+    assert response["data"]['path'] != None
+    assert response["data"]['dp'] != None
+    # the value itself may be "None", but the key must exist
+    assert 'value' in response["data"]['dp']
+    assert response["data"]['dp']['ts'] != None
+
+@then("I should receive a single value from a single node")
+def receive_ws_single_value_single_node(connected_clients, request_id):
+    envelope = connected_clients.find_message(request_id=request_id)
+    response = envelope["body"]
+    assert response["action"] == "get"
+    assert response["requestId"] != None
+    assert response["data"] != None
+    assert response["data"]['path'] != None
+    assert response["data"]['dp'] != None
+    # the value itself may be "None", but the key must exist
+    assert 'value' in response["data"]['dp']
+    assert response["data"]['dp']['ts'] != None
+
+@then("I should receive multiple data points")
+def receive_ws_read_multiple_datapoints(connected_clients,request_id):
+    responses = connected_clients.find_messages(request_id=request_id)
+    # TODO: Unpack envelope
+    # TODO: Count number of valid "dp" items
+    actual_count = len(responses)
+    assert actual_count > 1, f"Expected multiple messages but only got {actual_count}"
+
+@then("I should receive a single value from multiple nodes")
+def receive_ws_single_value_multiple_nodes(connected_clients,request_id):
+    responses = connected_clients.find_messages(request_id=request_id)
+    # TODO: Unpack envelope
+    # TODO: Count number of valid "dp" items
+    # TODO: Assert that each node only has 1 value
+    actual_count = len(responses)
+    assert actual_count > 1, f"Expected multiple messages but only got {actual_count}"
+
+@then(parsers.parse("I should receive exactly {expected_count:d} data points"))
+def receive_ws_read_expected_count(connected_clients,request_id, subscription_id, expected_count):
+    messages = connected_clients.find_messages(subscription_id=subscription_id)
+    actual_count = len(messages)
+    assert actual_count == expected_count, f"Expected {expected_count} messages but got {actual_count} for subscription {subscription_id}"
+
+@then("I should receive an error response")
+def receive_any_error_response(connected_clients,request_id):
+    envelope = connected_clients.find_message(request_id=request_id)
+    response = envelope["body"]
+    assert "requestId" in response
+    assert "error" in response
+
+@then(parsers.parse("I should receive an error response with number {error_code:d} and reason \"{error_reason}\""))
+def receive_specific_error_response(connected_clients,request_id,error_code,error_reason):
+    envelope = connected_clients.find_message(request_id=request_id)
+    response = envelope["body"]
+    assert "requestId" in response
+    assert "error" in response
+    assert error_code == response['error']['number'], f"Expected error code '{error_code}' but got '{response['error']['number']}'"
+    assert error_reason == response['error']['reason'], f"Expected error reason '{error_reason}' but got '{response['error']['reason']}'"
+
+@then("I should receive a valid subscribe response")
+def receive_ws_subscribe(connected_clients,request_id, subscription_id):
+    envelope = connected_clients.find_message(subscription_id=subscription_id,
+                                              request_id=request_id,
+                                              action="subscribe")
+    response = envelope["body"]
+    assert "subscriptionId" in response
+    assert "ts" in response
+    assert "error" not in response
+
+@then("I should receive a valid subscription response")
+def receive_ws_subscribe(connected_clients,request_id, subscription_id):
+    # Do not use the current request_id, as it's from the previous
+    # request.
+    envelope = connected_clients.find_message(subscription_id=subscription_id,
+                                              request_id=None,
+                                              action="subscription")
+    response = envelope["body"]
+    assert "action" in response
+    assert "subscriptionId" in response
+    assert "ts" in response
+    assert "requestId" not in response
+    assert "error" not in response
+
+@then("I should receive a subscribe error event")
+def receive_ws_subscribe_error_event(connected_clients,request_id):
+    envelope = connected_clients.find_message(request_id=request_id, action="subscribe")
+    response = envelope["body"]
+    assert "requestId" in response
+    assert "error" in response
+    assert "ts" in response
+    assert "subscriptionId" not in response
+
+    # Current implementation
+    assert response["error"] == {"number": 404,
+                                 "reason": "invalid_path",
+                                 "message": "The specified data path does not exist."}
+
+    # TODO: According to spec example:
+    # assert response["error"] == {"number": 404,
+    #                              "reason": "unavailable_data",
+    #                              "message": "The requested data was not found."}
+
+@then("I should receive a set error event")
+def receive_ws_set_error_event(connected_clients,request_id):
+    envelope = connected_clients.find_message(request_id=request_id, action="set")
+    response = envelope["body"]
+    assert "action" in response
+    assert "requestId" in response
+    assert "ts" in response
+    assert "error" in response
+
+    # Current implementation
+    assert response["error"] == {"number": 401,
+                                 "reason": "read_only",
+                                 "message": "The desired signal cannot be set since it is a read only signal."}
+
+@then("I should receive a valid unsubscribe response")
+def receive_ws_unsubscribe(connected_clients,request_id):
+    envelope = connected_clients.find_message(request_id=request_id, action="unsubscribe")
+    response = envelope["body"]
+    assert "action" in response
+    assert "subscriptionId" in response
+    assert "requestId" in response
+    assert "ts" in response
+
+    assert "error" not in response
+
+@then("I should receive a valid subscription event")
+def receive_ws_subscription(connected_clients,subscription_id,request_id):
+    # Ignore the request id here!
+    envelope = connected_clients.find_message(subscription_id=subscription_id,
+                                              request_id=None,
+                                              action="subscription")
+    response = envelope["body"]
+    assert "action" in response
+    assert "subscriptionId" in response
+    assert "ts" in response
+    assert "data" in response
+
+    assert "requestId" not in response
+
+    assert response["data"]['path'] != None
+    assert response["data"]['dp'] != None
+    # the value itself may be "None", but the key must exist
+    assert 'value' in response["data"]['dp']
+    assert response["data"]['dp']['ts'] != None
+
+@then("I should receive a valid set response")
+def receive_ws_set(connected_clients,request_id):
+    envelope = connected_clients.find_message(request_id=request_id,action="set")
+    response = envelope["body"]
+    assert "action" in response
+    assert "requestId" in response
+    assert "ts" in response
+
+    assert "error" not in response
+
+@then("I should receive a read-only error")
+def receive_ws_set_readonly_error(connected_clients,request_id):
+    envelope = connected_clients.find_message(request_id=request_id)
+    response = envelope["body"]
+    assert "action" in response
+    assert "requestId" in response
+    assert "ts" in response
+
+    assert response["action"] == "set"
+    assert response["requestId"] != None
+    assert response["ts"] != None
+    assert response["error"] == {"number": 401,
+                                "reason": "read_only",
+                                "message": "The desired signal cannot be set since it is a read only signal."}
+
+
+@then("I should receive a list of server capabilities")
+def receive_ws_list_of_server_capabilities(connected_clients,request_id):
+    envelope = connected_clients.find_message(request_id=request_id)
+    response = envelope["body"]
+    expected_response = {
+        "filter": [
+            "timebased",
+            "change",
+            "dynamic_metadata"
+        ],
+        "transport_protocol": [
+            "https",
+            "wss"
+        ]
+    }
+
+    assert expected_response == response, f"Expected server capabilites, but got: {response}"
+
+@when(parsers.parse('I request historical data for "{path}" with a timeframe of "{timeframe}"'))
+def request_historical_data(connected_clients, request_id, path, timeframe):
+    request = {
+        "action": "get",
+        "path": path,
+        "filter": {
+            "type": "history",
+            "parameter": timeframe
+        },
+        "requestId": request_id.new()
+    }
+    connected_clients.send(request_id, request)
+
+@when(parsers.parse('\"{path}\" has been updated multiple times over the past {duration:d} minutes'))
+@given(parsers.parse('\"{path}\" has been updated multiple times over the past {duration:d} minutes'))
+def update_signal_multiple_times(connected_clients, request_id, path, duration):
+    import time
+
+    updates = [
+        {"value": 50, "delay": 1},
+        {"value": 60, "delay": 1},
+        {"value": 70, "delay": 1},
+    ]
+
+    for update in updates:
+        request = {
+            "action": "set",
+            "path": path,
+            "requestId": request_id.new(),
+            "value": update["value"]
+        }
+        connected_clients.send(request_id, request)
+        time.sleep(update["delay"])  # Simulate a time gap between updates
+
+    logger.debug(f"Updated {path} multiple times over {duration} minutes.")
+
+
+@then("I should receive a list of past data points within the last hour")
+@then("I should receive multiple past data points from the last 24 hours")
+def validate_historical_data_points(connected_clients, request_id):
+    envelope = connected_clients.find_message(request_id=request_id, action="get")
+    response = envelope["body"]
+    assert "data" in response, "No data field found in response"
+    assert isinstance(response["data"], list), "Expected a list of historical data points"
+    assert len(response["data"]) > 1, "Expected multiple historical data points"
+
+
+@then("the timestamps should be in chronological order")
+def validate_timestamps_order(connected_clients, request_id):
+    envelope = connected_clients.find_message(request_id=request_id, action="get")
+    response = envelope["body"]
+    timestamps = [dp["ts"] for dp in response["data"]]
+    assert timestamps == sorted(timestamps), "Timestamps are not in chronological order"
+
+
+@then("I should receive an error response indicating an invalid timeframe format")
+def validate_invalid_timeframe_error(connected_clients, request_id):
+    envelope = connected_clients.find_message(request_id=request_id, action="get")
+    response = envelope["body"]
+    assert "error" in response, "Expected an error in response"
+    assert response["error"]["reason"] == "invalid_timeframe", f"Unexpected error reason: {response['error']['reason']}"
+
+
+@then("I should receive an empty data response")
+def validate_empty_history_response(connected_clients, request_id):
+    envelope = connected_clients.find_message(request_id=request_id, action="get")
+    response = envelope["body"]
+    assert "data" in response, "Expected a data field in response"
+    assert response["data"] == [], "Expected an empty data list"
+
+
+@then("I should receive a set of past data points matching the recorded values")
+@then("the values should be accurate compared to previous set requests")
+def validate_historical_data_consistency(connected_clients, request_id):
+    envelope = connected_clients.find_message(request_id=request_id, action="get")
+    response = envelope["body"]
+    assert "data" in response, f"Expected a data field in response, but got {response}"
+
+    # Retrieve the last known values from previous set requests (mocked for this example)
+    expected_values = [123, 130, 125]  # Replace with actual recorded values
+    received_values = [dp["value"] for dp in response["data"]]
+
+    assert received_values == expected_values, f"Expected values {expected_values} but got {received_values}"
+
+@when(parsers.parse('I request historical data for "{path}" with a timeframe of "{timeframe}"'))
+def request_historical_data_multiple_nodes(connected_clients, request_id, path, timeframe):
+    request = {
+        "action": "get",
+        "path": path,
+        "filter": {
+            "type": "history",
+            "parameter": timeframe
+        },
+        "requestId": request_id.new()
+    }
+    connected_clients.send(request_id, request)
+
+
+@then("I should receive historical data for multiple nodes")
+def validate_historical_data_multiple_nodes(connected_clients, request_id):
+    envelope = connected_clients.find_message(request_id=request_id, action="get")
+    response = envelope["body"]
+    assert "data" in response, "No data field found in response"
+    assert isinstance(response["data"], list), "Expected a list of historical data points"
+
+    # Ensure that multiple unique paths exist
+    unique_paths = set(dp["path"] for dp in response["data"])
+    assert len(unique_paths) > 1, "Expected historical data from multiple nodes, but only found one"
+
+
+@then("the response should include data from at least two different paths")
+def validate_multiple_paths_in_history_response(connected_clients, request_id):
+    envelope = connected_clients.find_message(request_id=request_id, action="get")
+    response = envelope["body"]
+    assert "data" in response, "No data field found in response"
+    paths = set(dp["path"] for dp in response["data"])
+    assert len(paths) >= 2, f"Expected at least two different paths, but got {len(paths)}"
+
+@when(parsers.parse('I send a bulk set request with the following values:'))
+def send_bulk_set_request(connected_clients, request_id, datatable):
+    bulk_request = {
+        "action": "set",
+        "values": [],
+        "requestId": request_id.new()
+    }
+
+    for row in datatable[1:]:
+        path = row[0]
+        value = row[1]
+        bulk_request["values"].append({"path": path, "value": value})
+
+    connected_clients.send(request_id, bulk_request)
+
+@then("I should receive a valid response")
+def validate_successful_response(connected_clients, request_id):
+    envelope = connected_clients.find_message(request_id=request_id)
+    response = envelope["body"]
+    assert "action" in response, "Response is missing 'action' field"
+    assert "requestId" in response, "Response is missing 'requestId'"
+    assert "error" not in response, f"Unexpected error in response: {response.get('error')}"
+
+    logger.debug(f"Received valid response: {response}")
+
+# TODO: There seems to be a duplicate function
+@then("I should receive a valid set response")
+def validate_successful_set_response(connected_clients, request_id):
+    envelope = connected_clients.find_message(request_id=request_id)
+    response = envelope["body"]
+    assert "action" in response, "Response is missing 'action' field"
+    assert "requestId" in response, "Response is missing 'requestId'"
+    assert "error" not in response, f"Unexpected error in response: {response.get('error')}"
+
+    assert "set" == response['action'], f"Response should be for set, but is for {response['action']}"
+
+    logger.debug(f"Received valid response: {response}")
+
+@then(parsers.parse("I should receive a valid set response for \"{path}\""))
+def validate_successful_set_response_for_path(connected_clients, request_id,path):
+    envelope = connected_clients.find_message(request_id=request_id)
+    response = envelope["body"]
+    assert "action" in response, "Response is missing 'action' field"
+    assert "path" in response, "Response is missing 'path' field"
+    assert "requestId" in response, "Response is missing 'requestId'"
+    assert "error" not in response, f"Unexpected error in response: {response.get('error')}"
+
+    assert "set" == response['action'], f"Response should be for set, but is for {response['action']}"
+    assert path == response['path'], f"Response should be for {path}, but is for {response['path']}"
+
+    logger.debug(f"Received valid response: {response}")

--- a/integration_test/viss/tests/test_steps/websockets_viss_client.py
+++ b/integration_test/viss/tests/test_steps/websockets_viss_client.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# /********************************************************************************
+# * Copyright (c) 2025 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+import json
+import logging
+import websocket
+import time
+from tinydb import TinyDB, Query, where
+from tinydb.storages import MemoryStorage
+from .types import RequestId
+TinyDB.default_storage_class = MemoryStorage
+logger = logging.getLogger(__name__)
+
+class WebSocketsVISSClient:
+
+    def __init__(self, pytestconfig):
+        self.pytestconfig = pytestconfig
+        self.received_messages = TinyDB()
+        self.sent_messages = TinyDB()
+        self._client_is_connected = False
+
+    def is_connected(self)-> bool:
+        return self._client_is_connected
+
+    def connect(self):
+        self._client_is_connected = True
+        self._ws = websocket.create_connection(self.pytestconfig.getini('viss_ws_base_url'),
+                                               timeout=float(self.pytestconfig.getini('viss_connect_timeout')))
+
+    def disconnect(self):
+        self._client_is_connected = False
+
+    def send(self, request_id, message, authorization=None):
+        # TODO: request_id is already in message. Why duplicate?
+        if authorization:
+            logger.debug("Injecting authorization token to websocket message")
+            message["authorization"] = authorization["token"]
+        self._ws.send(json.dumps(message))
+        envelope = {
+            "protocol": "websockets",
+            "timestamp": time.time(),
+            "action": message['action'],
+            "requestId": request_id.current(),
+            "body": message
+        }
+        logger.debug(f"Storing sent envelope: {envelope}")
+        self.sent_messages.insert(envelope)
+        self._read_all_websocket_messages()
+
+    # TODO: message should be "consumed" by the test, e.g. only checked once and then removed from the list of
+    # received messages.
+
+    def _read_all_websocket_messages(self):
+        self._ws.settimeout(float(self.pytestconfig.getini('viss_message_timeout')))
+        while True:
+            try:
+                message = json.loads(self._ws.recv())
+                envelope = {
+                    "protocol": "websockets",
+                    "timestamp": time.time(),
+                    "body": message
+                }
+                if "requestId" in message:
+                    envelope['requestId'] = message['requestId']
+                if "subscriptionId" in message:
+                    envelope['subscriptionId'] = message['subscriptionId']
+                if "action" in message:
+                    envelope['action'] = message['action']
+                self.received_messages.insert(envelope)
+                logger.debug(f"Storing received envelope: {envelope}")
+            except websocket.WebSocketTimeoutException:
+                logger.debug("No new messages, stopping read.")
+                break  # Exit loop when no new messages arrive
+            except websocket.WebSocketException as e:
+                logger.warning(f"WebSocket error: {e}")
+                break  # Exit on WebSocket errors
+
+    def find_subscription_id_by_request_id(self, request_id):
+        search_template = Query()
+        logger.debug(f"Searching received messages for the subscriptionId with requestId={request_id.current()}")
+        result = max(self.received_messages.search(
+                       (search_template.requestId == request_id.current())
+                     & (search_template.action == 'subscribe')
+                  ), key=lambda x: x["timestamp"], default=None)
+        logger.debug(f"Found received message:{result}")
+        if result:
+            if "subscriptionId" in result:
+                return result['subscriptionId']
+        # Allow invalid subscriptions, eg to test for error situations
+        # where no subscription is actually created
+        return None
+
+    def find_messages(self, *,
+                      subscription_id : str = None,
+                      request_id : RequestId = None,
+                      action : str = None,
+                      authorization = None):
+        # Initialize a list to hold conditions
+        conditions = []
+
+        if subscription_id:
+            logger.debug(f"Adding search condition subscriptionId={subscription_id}")
+            conditions.append(where('subscriptionId') == subscription_id)
+        if request_id:
+            logger.debug(f"Adding search condition requestId={request_id.current()}")
+            conditions.append(where('requestId') == request_id.current())
+        if action:
+            logger.debug(f"Adding search condition action={action}")
+            conditions.append(where('action') == action)
+
+        search_template = Query()
+        # Combine conditions using AND if there are any
+        if conditions:
+            search_template = conditions[0]  # Start with the first condition
+            for condition in conditions[1:]:
+                search_template &= condition  # Combine with AND
+
+        logger.debug(f"Query template: {search_template}")
+        results = self.received_messages.search(search_template)
+        logger.debug(f"Found messages: {results}")
+        return results
+
+    def find_message(self, *,
+                     subscription_id=None,
+                     request_id=None,
+                     action=None,
+                     authorization=None):
+        results = self.find_messages(subscription_id=subscription_id,
+                                     request_id=request_id,
+                                     action=action,
+                                     authorization=authorization)
+        result = max(results,key=lambda x: x["timestamp"], default=None)
+        logger.debug(f"Found latest message: {result}")
+        return result

--- a/integration_test/viss/tests/test_viss_v2.py
+++ b/integration_test/viss/tests/test_viss_v2.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# /********************************************************************************
+# * Copyright (c) 2025 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+from pytest_bdd import scenarios
+from test_steps.viss_v2_steps import *  # Import step definitions
+import os
+
+# Unset proxy settings, to make sure we're connecting to localhost
+os.environ.pop("HTTP_PROXY", None)
+os.environ.pop("HTTPS_PROXY", None)
+os.environ["NO_PROXY"] = "*"
+
+# Point to the feature file
+scenarios("../features/viss_v2_basic.feature")
+scenarios("../features/viss_v2_core_read.feature")
+scenarios("../features/viss_v2_core_update.feature")
+scenarios("../features/viss_v2_core_subscribe.feature")
+scenarios("../features/viss_v2_core_unsubscribe.feature")
+scenarios("../features/viss_v2_core_authorization.feature")
+scenarios("../features/viss_v2_bulk_updates.feature")
+scenarios("../features/viss_v2_history_data.feature")
+scenarios("../features/viss_v2_multiple_paths.feature")
+scenarios("../features/viss_v2_server_capabilities.feature")
+scenarios("../features/viss_v2_transport_wss_filter.feature")
+scenarios("../features/viss_v2_transport_http_read.feature")
+scenarios("../features/viss_v2_transport_mqtt_read.feature")

--- a/integration_test/viss/tests/test_viss_v3.py
+++ b/integration_test/viss/tests/test_viss_v3.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# /********************************************************************************
+# * Copyright (c) 2025 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+from pytest_bdd import scenarios
+from test_steps.viss_v2_steps import *  # Import step definitions
+import os
+
+# Unset proxy settings, to make sure we're connecting to localhost
+os.environ.pop("HTTP_PROXY", None)
+os.environ.pop("HTTPS_PROXY", None)
+os.environ["NO_PROXY"] = "*"
+
+# Point to the feature file
+scenarios("../features/viss_v3_basic.feature")
+scenarios("../features/viss_v3_core_read.feature")
+scenarios("../features/viss_v3_transport_grpc.feature")
+scenarios("../features/viss_v3_transport_http.feature")
+scenarios("../features/viss_v3_transport_mqtt.feature")
+scenarios("../features/viss_v3_transport_wss.feature")


### PR DESCRIPTION
Context: as a preparation for integration of Eclipse Kuksa Databroker into Adaptive AutoSAR R24-11 as Automotive API Gateway "VISS server".

Starting to create new integration tests for testing coverage of the Databroker VISS server in regard to the COVESA VISS v2.0 specification.

Tests are based on python-bdd, Gherkin syntax for features.

Currently, databroker supports the WebSockets protocol only. Rudimentary tests for the core features for HTTP have been added, and MQTT is prepared.

Status:
- 63 tests total / 24 failing
- Covers all basic operations (get, update, subscribe, unsubscribe) and mandatory features (authorization, filters)

References:
- https://github.com/COVESA/vehicle-information-service-specification
- https://www.autosar.org/fileadmin/standards/R24-11/AP/AUTOSAR_AP_EXP_AutomotiveAPI.pdf

Non-exclusive list of AutoSAR requirements covered by this test suite:
- [AP_RS_AAG_00040] VISS interface
- [AP_RS_AAG_00050] VISS Read of Multiple Leaves
- [AP_RS_AAG_00051] VISS Subscriptions
- [AP_RS_AAG_00060] VISS Change Filter
- [AP_RS_AAG_00061] VISS Timebased filter
- [AP_RS_AAG_00062] VISS Server Capabilities
- [AP_SWS_AAG_20003] Authorization
- [AP_SWS_AAG_20005] Rejection of Unsupported Filters
