### PR TITLE
Fix warnings in updated clippy

### DIFF
--- a/databroker-cli/src/sdv_cli.rs
+++ b/databroker-cli/src/sdv_cli.rs
@@ -951,8 +951,6 @@ impl<Term: Terminal> Completer<Term> for CliCompleter {
 
 struct DisplayDataType(Option<proto::v1::DataType>);
 struct DisplayEntryType(Option<proto::v1::EntryType>);
-// !!! ChangeType currently just exists in old API needs to be removed or added later !!!
-struct DisplayChangeType(Option<proto::v1::ChangeType>);
 struct DisplayDatapoint(proto::v1::Datapoint);
 
 fn display_array<T>(f: &mut fmt::Formatter<'_>, array: &[T]) -> fmt::Result
@@ -1022,20 +1020,6 @@ impl From<Option<proto::v1::DataType>> for DisplayDataType {
 }
 
 impl fmt::Display for DisplayDataType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.0 {
-            Some(data_type) => f.pad(&format!("{data_type:?}")),
-            None => f.pad("Unknown"),
-        }
-    }
-}
-
-impl From<Option<databroker_proto::sdv::databroker::v1::ChangeType>> for DisplayChangeType {
-    fn from(input: Option<databroker_proto::sdv::databroker::v1::ChangeType>) -> Self {
-        DisplayChangeType(input)
-    }
-}
-impl fmt::Display for DisplayChangeType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
             Some(data_type) => f.pad(&format!("{data_type:?}")),

--- a/databroker/src/glob.rs
+++ b/databroker/src/glob.rs
@@ -1194,7 +1194,7 @@ mod tests {
             }
         }
 
-        fn with_signals(&self, signals: &'a [&str]) -> TestSignals {
+        fn with_signals(&self, signals: &'a [&str]) -> TestSignals<'_> {
             TestSignals::new(self, signals)
         }
 
@@ -1217,7 +1217,7 @@ mod tests {
         }
     }
 
-    fn using_glob(glob: &str) -> TestGlob {
+    fn using_glob(glob: &str) -> TestGlob<'_> {
         TestGlob::new(glob)
     }
 
@@ -2616,7 +2616,7 @@ mod tests_glob_matching {
             }
         }
 
-        fn with_signals(&self, signals: &'a [&str]) -> TestSignalsGlobMatching {
+        fn with_signals(&self, signals: &'a [&str]) -> TestSignalsGlobMatching<'_> {
             TestSignalsGlobMatching::new(self, signals)
         }
 
@@ -2639,7 +2639,7 @@ mod tests_glob_matching {
         }
     }
 
-    fn using_glob_matching(glob: &str) -> TestGlobMatching {
+    fn using_glob_matching(glob: &str) -> TestGlobMatching<'_> {
         TestGlobMatching::new(glob)
     }
 


### PR DESCRIPTION
This fixes several clippy issues or compiler warings that triggered clippy to fail such as

```
warning: struct `DisplayChangeType` is never constructed
   --> databroker-cli/src/sdv_cli.rs:955:8
    |
955 | struct DisplayChangeType(Option<proto::v1::ChangeType>);
    |        ^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default

```

or 

```
warning: hiding a lifetime that's elided elsewhere is confusing
    --> databroker/src/broker.rs:1341:25
     |
1341 |     pub fn iter_entries(&self) -> EntryReadIterator {
     |                         ^^^^^     -----------------
     |                         |         |
     |                         |         the same lifetime is hidden here
     |                         |         the same lifetime is hidden here
     |                         the lifetime is elided here
     |
     = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
     = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
     |
1341 |     pub fn iter_entries(&self) -> EntryReadIterator<'_> {
     |                                                    ++++

warning: `databroker` (lib) generated 1 warning
```


As long as we do not fix it, any CI runs will fail, see eg. the currently open dependabot PRs