### PR TITLE
fix: return FAILED_PRECONDITION instead of UNAVAILABLE when no actuation provider registered

### DIFF
--- a/databroker/src/grpc/kuksa_val_v2/conversions.rs
+++ b/databroker/src/grpc/kuksa_val_v2/conversions.rs
@@ -530,7 +530,9 @@ impl broker::ActuationError {
             broker::ActuationError::UnsupportedType => tonic::Status::invalid_argument(message),
             broker::ActuationError::PermissionDenied => tonic::Status::permission_denied(message),
             broker::ActuationError::PermissionExpired => tonic::Status::unauthenticated(message),
-            broker::ActuationError::ProviderNotAvailable => tonic::Status::unavailable(message),
+            broker::ActuationError::ProviderNotAvailable => {
+                tonic::Status::failed_precondition(message)
+            }
             broker::ActuationError::ProviderAlreadyExists => tonic::Status::already_exists(message),
             broker::ActuationError::TransmissionFailure => tonic::Status::data_loss(message),
         }

--- a/databroker/src/grpc/kuksa_val_v2/val.rs
+++ b/databroker/src/grpc/kuksa_val_v2/val.rs
@@ -569,7 +569,7 @@ impl proto::val_server::Val for broker::DataBroker {
     //   NOT_FOUND if the actuator does not exist.
     //   PERMISSION_DENIED if access is denied for the actuator.
     //   UNAUTHENTICATED if no credentials provided or credentials has expired
-    //   UNAVAILABLE if there is no provider currently providing the actuator
+    //   FAILED_PRECONDITION if there is no provider currently providing the actuator
     //   DATA_LOSS is there is a internal TransmissionFailure
     //   INVALID_ARGUMENT
     //       - if the provided path is not an actuator.
@@ -635,7 +635,7 @@ impl proto::val_server::Val for broker::DataBroker {
     //   NOT_FOUND if any of the actuators are non-existant.
     //   PERMISSION_DENIED if access is denied for any of the actuators.
     //   UNAUTHENTICATED if no credentials provided or credentials has expired
-    //   UNAVAILABLE if there is no provider currently providing an actuator
+    //   FAILED_PRECONDITION if there is no provider currently providing an actuator
     //   DATA_LOSS is there is a internal TransmissionFailure
     //   INVALID_ARGUMENT
     //       - if the data type used in the request does not match
@@ -3041,7 +3041,7 @@ mod tests {
         assert!(result_response.is_err());
         assert_eq!(
             result_response.unwrap_err().code(),
-            tonic::Code::Unavailable
+            tonic::Code::FailedPrecondition
         )
     }
 
@@ -3368,7 +3368,7 @@ mod tests {
         assert!(result_response.is_err());
         assert_eq!(
             result_response.unwrap_err().code(),
-            tonic::Code::Unavailable
+            tonic::Code::FailedPrecondition
         )
     }
 
@@ -3695,7 +3695,7 @@ mod tests {
                 panic!("Should not happen")
             }
             Err(err) => {
-                assert_eq!(err.code(), tonic::Code::Unavailable)
+                assert_eq!(err.code(), tonic::Code::FailedPrecondition)
             }
         }
     }


### PR DESCRIPTION
## Fix #173: Replace `UNAVAILABLE` with `FAILED_PRECONDITION` when no actuation provider is registered

### Problem

When a client calls `actuate` or `batch_actuate` and no provider has registered for the
requested actuator signal, the databroker returns gRPC status **`UNAVAILABLE`**.

This is semantically wrong. According to the gRPC status code specification:

> **`UNAVAILABLE`** — The service is currently unavailable. This is most likely a transient condition
> which can be corrected by retrying with a backoff. **(Client should retry.)**

> **`FAILED_PRECONDITION`** — The operation was rejected because the system is not in a state
> required for the operation's execution. **(Client should not retry. Fix the state first.)**

"No provider registered" is **not** a transient network error. The broker is running and healthy;
the precondition for actuation (an active provider) simply has not been met. Returning `UNAVAILABLE`
causes gRPC retry middleware — and specifically `kuksa_dart_sdk` — to retry indefinitely, burning
CPU and flooding logs, instead of surfacing a clear error to the application.

### Root cause

`databroker/src/grpc/kuksa_val_v2/conversions.rs`, `ActuationError::to_tonic_status()`:

```rust
// Before
broker::ActuationError::ProviderNotAvailable => tonic::Status::unavailable(message),
```

### Fix

Changed to `failed_precondition` in the status mapping, and updated the corresponding
documentation comments in `val.rs` and the three unit test assertions that verify this
error path (`test_actuate_can_provider_unavailable`, `test_batch_actuate_provider_unavailable`,
`test_actuate_stream_can_provider_unavailable`).

```rust
// After
broker::ActuationError::ProviderNotAvailable => {
    tonic::Status::failed_precondition(message)
}
```

### Files changed

| File | Change |
|------|--------|
| `databroker/src/grpc/kuksa_val_v2/conversions.rs:533` | Status mapping: `unavailable` → `failed_precondition` |
| `databroker/src/grpc/kuksa_val_v2/val.rs:572` | Doc comment: `UNAVAILABLE` → `FAILED_PRECONDITION` |
| `databroker/src/grpc/kuksa_val_v2/val.rs:638` | Doc comment: `UNAVAILABLE` → `FAILED_PRECONDITION` |
| `databroker/src/grpc/kuksa_val_v2/val.rs:3044` | Test assertion: `Code::Unavailable` → `Code::FailedPrecondition` |
| `databroker/src/grpc/kuksa_val_v2/val.rs:3371` | Test assertion: `Code::Unavailable` → `Code::FailedPrecondition` |
| `databroker/src/grpc/kuksa_val_v2/val.rs:3698` | Test assertion: `Code::Unavailable` → `Code::FailedPrecondition` |

### Testing

All three existing unit tests for the provider-not-available path continue to pass after
updating their assertions from `Code::Unavailable` to `Code::FailedPrecondition`. No
behavior changes beyond the status code itself.

### Closes

Fixes #173

---

*AI-assisted — authored with Claude, reviewed by Komada.*