### PR TITLE
fix: honour min_sample_interval for change-driven subscription updates

### DIFF
--- a/databroker/src/broker.rs
+++ b/databroker/src/broker.rs
@@ -5058,4 +5058,67 @@ pub mod tests {
             }
         }
     }
+
+    /// Regression test for issue #186 (<https://github.com/eclipse-kuksa/kuksa-databroker/issues/186>).
+    ///
+    /// With `min_sample_interval` set, the initial value notification
+    /// (`changed == None`) must always be delivered immediately on subscribe,
+    /// regardless of `last_emitted`.  Before the fix, `last_emitted` was
+    /// initialised to `Instant::now()` at subscription creation, so
+    /// `elapsed() ≈ 0 < interval_duration` caused the throttle guard — which
+    /// was placed *before* `match changed` — to suppress the initial
+    /// notification.  The fix moves the guard inside the `Some(changed)` arm
+    /// so it never affects the `None` (initial) notification path.
+    #[tokio::test]
+    async fn test_subscribe_initial_notification_delivered_with_min_sample_interval() {
+        let broker = DataBroker::default();
+        let broker = broker.authorized_access(&permissions::ALLOW_ALL);
+
+        let id1 = broker
+            .add_entry(
+                "test.datapoint1".to_owned(),
+                DataType::Int32,
+                ChangeType::OnChange,
+                EntryType::Sensor,
+                "Test datapoint".to_owned(),
+                None, // min
+                None, // max
+                None,
+                None,
+            )
+            .await
+            .expect("Register datapoint should succeed");
+
+        // Subscribe with a large min_sample_interval (5 s).
+        // The initial notification (changed == None) must arrive immediately
+        // even though last_emitted was just set to Instant::now().
+        let mut stream = broker
+            .subscribe(
+                HashMap::from([(id1, HashSet::from([Field::Datapoint]))]),
+                None,
+                Some(5000), // 5 000 ms min_sample_interval
+            )
+            .await
+            .expect("subscription should succeed");
+
+        match tokio::time::timeout(std::time::Duration::from_secs(1), stream.next()).await {
+            Ok(Some(Some(value))) => {
+                assert_eq!(value.updates.len(), 1);
+                assert_eq!(
+                    value.updates[0].update.path,
+                    Some("test.datapoint1".to_string())
+                );
+                assert_eq!(
+                    value.updates[0].update.datapoint.as_ref().unwrap().value,
+                    DataValue::NotAvailable
+                );
+            }
+            Ok(Some(None)) => panic!("stream closed unexpectedly"),
+            Ok(None) => panic!("stream ended without initial notification"),
+            Err(_) => panic!(
+                "timed out: initial notification was not delivered with min_sample_interval \
+                 — regression of issue #186 (throttle guard must not block changed == None)"
+            ),
+        }
+    }
 }

--- a/databroker/src/broker.rs
+++ b/databroker/src/broker.rs
@@ -954,16 +954,14 @@ impl ChangeSubscription {
         changed: Option<&HashMap<i32, HashSet<Field>>>,
         db: &Database,
     ) -> Result<(), NotificationError> {
-        if self.interval_duration.is_some()
-            && self.last_emitted.read().await.elapsed().as_millis()
-                < self.interval_duration.unwrap().as_millis()
-        {
-            return Ok(());
-        }
-
         let db_read = db.authorized_read_access(&self.permissions);
         match changed {
             Some(changed) => {
+                if let Some(duration) = self.interval_duration {
+                    if self.last_emitted.read().await.elapsed() < duration {
+                        return Ok(());
+                    }
+                }
                 let mut matches = false;
                 for (id, changed_fields) in changed {
                     if let Some(fields) = self.entries.get(id) {


### PR DESCRIPTION
## Problem

`Filter.min_sample_interval` was introduced in #141 and stored in
`ChangeSubscription.interval_duration`, but the throttle guard in
`ChangeSubscription::notify()` was placed **before** the `match changed`
branch. Because `last_emitted` is initialised to `Instant::now()` at
subscription creation, `elapsed() ≈ 0` at the moment the initial value
notification fires. This is always less than any non-zero interval,
so the initial push was **always blocked** regardless of the interval
value — subscribers never received the current signal value on subscribe.

Closes #186.

## Root cause

```rust
// Before fix — guard fires for BOTH Some(changed) and None
if self.interval_duration.is_some()
    && self.last_emitted.read().await.elapsed().as_millis()
        < self.interval_duration.unwrap().as_millis()
{
    return Ok(()); // ← blocked initial notification too
}
match changed {
    Some(changed) => { /* change-driven update */ }
    None          => { /* initial value fetch — was never reached */ }
}
```

## Fix

Move the throttle guard inside the `Some(changed)` branch. The `None`
branch (initial subscription value delivery) is now always executed
regardless of the configured interval.

```rust
match changed {
    Some(changed) => {
        // Honour min_sample_interval: skip change-driven notifications
        // that arrive faster than the requested interval. The initial
        // notification (changed == None) is always delivered so the
        // subscriber receives the current value immediately on subscribe.
        if let Some(duration) = self.interval_duration {
            if self.last_emitted.read().await.elapsed() < duration {
                return Ok(());
            }
        }
        // ... rest of change-driven path
    }
    None => { /* initial value — always delivered */ }
}
```

## Testing

Manually verified logic against the `ChangeSubscription::notify()`
control flow. A unit test that creates a subscription with a non-zero
`min_sample_interval` and asserts the first `notify(None)` call returns
`Ok(())` would fully cover this.

*AI-assisted — authored with Claude, reviewed by Komada.*