### PR TITLE
feat: add broadcast_drops_total OpenTelemetry counter (#200)

### DIFF
--- a/databroker/Cargo.toml
+++ b/databroker/Cargo.toml
@@ -72,7 +72,7 @@ chrono = { version = "0.4.31", optional = true, features = ["std"] }
 uuid = { version = "1.4.1", features = ["v4"] }
 
 # OTEL
-opentelemetry = { version = "0.19.0", optional = true, features = ["rt-tokio", "trace"] }
+opentelemetry = { version = "0.19.0", optional = true, features = ["rt-tokio", "trace", "metrics"] }
 opentelemetry-otlp = { version="0.12.0", optional = true,  features = ["tonic", "metrics"] }
 opentelemetry-semantic-conventions = { version="0.11.0", optional = true }
 tracing-opentelemetry = { version="0.19.0", optional = true }

--- a/databroker/src/broker.rs
+++ b/databroker/src/broker.rs
@@ -21,6 +21,7 @@ pub use crate::types::{ChangeType, DataType, DataValue, EntryType, SignalId, Tim
 use indexmap::IndexMap;
 use tokio::sync::{broadcast, mpsc, RwLock};
 use tokio::time::Instant;
+use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 use tokio_stream::wrappers::{BroadcastStream, ReceiverStream};
 use tokio_stream::{Stream, StreamExt};
 
@@ -1845,11 +1846,15 @@ impl AuthorizedAccess<'_, '_> {
 
         let stream = BroadcastStream::new(receiver).map(move |result| match result {
             Ok(message) => message,
-            Err(err) => {
+            Err(BroadcastStreamRecvError::Lagged(n)) => {
                 warn!(
-                    "Slow subscriber with capacity {} lagged and missed signal updates: {}",
-                    channel_capacity, err
+                    "Slow subscriber with capacity {} lagged, missed {} signal updates",
+                    channel_capacity, n
                 );
+                #[cfg(feature = "otel")]
+                if let Some(counter) = crate::open_telemetry::broadcast_drop_counter() {
+                    counter.add(&opentelemetry::Context::current(), n, &[]);
+                }
                 None
             }
         });
@@ -5118,6 +5123,37 @@ pub mod tests {
             Err(_) => panic!(
                 "timed out: initial notification was not delivered with min_sample_interval \
                  — regression of issue #186 (throttle guard must not block changed == None)"
+            ),
+        }
+    }
+
+    /// Regression test for issue #200 (broadcast_drops_total counter).
+    ///
+    /// Asserts the API assumption that `BroadcastStreamRecvError::Lagged(n)`
+    /// destructures with a non-zero count when the broadcast channel overflows
+    /// before the first receive. This is the exact pattern used in
+    /// `subscribe_change`'s stream adapter at broker.rs.
+    #[tokio::test]
+    async fn test_broadcast_stream_lagged_variant_exposes_drop_count() {
+        use tokio::sync::broadcast;
+        use tokio_stream::wrappers::BroadcastStream;
+
+        let (tx, rx) = broadcast::channel::<u32>(2);
+        let mut stream = BroadcastStream::new(rx);
+
+        // Send more than the channel capacity before any receive. The first
+        // stream poll must surface a Lagged(n) with n >= 1.
+        for i in 0..5u32 {
+            tx.send(i).expect("send to live receiver should succeed");
+        }
+
+        match stream.next().await {
+            Some(Err(BroadcastStreamRecvError::Lagged(n))) => {
+                assert!(n >= 1, "expected at least 1 lagged message, got {n}");
+            }
+            other => panic!(
+                "expected first item to be Err(Lagged(_)), got {other:?} — \
+                 broadcast_drops_total counter depends on this variant"
             ),
         }
     }

--- a/databroker/src/lib.rs
+++ b/databroker/src/lib.rs
@@ -32,7 +32,8 @@ use tracing_subscriber::filter::EnvFilter;
 
 #[cfg(feature = "otel")]
 use {
-    open_telemetry::init_trace, opentelemetry::global,
+    open_telemetry::{init_metrics, init_trace},
+    opentelemetry::global,
     opentelemetry::sdk::propagation::TraceContextPropagator,
     tracing_subscriber::layer::SubscriberExt,
 };
@@ -62,6 +63,11 @@ pub fn init_logging() {
 
     // Initialize OpenTelemetry tracer
     let tracer = init_trace().expect("Failed to initialize tracer");
+
+    // Initialize OpenTelemetry metrics pipeline (used for broadcast_drops_total
+    // and any future counters). Held via the global meter provider; the
+    // controller handle is dropped here and managed internally.
+    let _controller = init_metrics().expect("Failed to initialize metrics provider");
 
     // telemetry layer
     let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);

--- a/databroker/src/open_telemetry.rs
+++ b/databroker/src/open_telemetry.rs
@@ -13,11 +13,20 @@
 
 #[cfg(feature = "otel")]
 use {
-    opentelemetry::sdk::{trace, Resource},
-    opentelemetry::trace::TraceError,
-    opentelemetry::{runtime, KeyValue},
+    opentelemetry::{
+        global,
+        metrics::{Counter, MetricsError},
+        runtime,
+        sdk::{
+            export::metrics::aggregation::cumulative_temporality_selector,
+            metrics::{controllers::BasicController, selectors},
+            trace, Resource,
+        },
+        trace::TraceError,
+        KeyValue,
+    },
     opentelemetry_otlp::WithExportConfig,
-    std::env,
+    std::{env, sync::OnceLock},
 };
 
 #[cfg(feature = "otel")]
@@ -35,4 +44,55 @@ pub fn init_trace() -> Result<trace::Tracer, TraceError> {
             )])),
         )
         .install_batch(runtime::Tokio)
+}
+
+#[cfg(feature = "otel")]
+static BROADCAST_DROP_COUNTER: OnceLock<Counter<u64>> = OnceLock::new();
+
+// Initialises the OpenTelemetry metrics pipeline (OTLP over tonic).
+//
+// Honours the same OTEL_ENDPOINT environment variable as init_trace and
+// registers the resulting BasicController as the global meter provider.
+// The broadcast-drop counter is cached for use from broker.rs.
+#[cfg(feature = "otel")]
+pub fn init_metrics() -> Result<BasicController, MetricsError> {
+    let controller = opentelemetry_otlp::new_pipeline()
+        .metrics(
+            selectors::simple::inexpensive(),
+            cumulative_temporality_selector(),
+            runtime::Tokio,
+        )
+        .with_exporter(opentelemetry_otlp::new_exporter().tonic().with_endpoint(
+            env::var("OTEL_ENDPOINT").unwrap_or_else(|_| "http://localhost:4317".to_string()),
+        ))
+        .with_resource(Resource::new(vec![KeyValue::new(
+            opentelemetry_semantic_conventions::resource::SERVICE_NAME,
+            "kuksa-rust-app",
+        )]))
+        .build()?;
+
+    global::set_meter_provider(controller.clone());
+
+    let meter = global::meter("kuksa-databroker");
+    let counter = meter
+        .u64_counter("broadcast_drops_total")
+        .with_description(
+            "Count of signal updates dropped due to slow subscribers \
+             (Tokio broadcast-channel lag events).",
+        )
+        .init();
+
+    // First caller wins; a later double-init leaves the existing counter in
+    // place rather than raising. This matches init_trace's .expect() posture
+    // in lib.rs — init is expected once per process.
+    let _ = BROADCAST_DROP_COUNTER.set(counter);
+
+    Ok(controller)
+}
+
+// Returns the broadcast-drop counter if init_metrics has run, or None
+// otherwise. Call sites should treat None as a no-op.
+#[cfg(feature = "otel")]
+pub fn broadcast_drop_counter() -> Option<&'static Counter<u64>> {
+    BROADCAST_DROP_COUNTER.get()
 }


### PR DESCRIPTION
## Summary

Closes #200.

Add a `broadcast_drops_total` OpenTelemetry counter that increments by `n` when `BroadcastStreamRecvError::Lagged(n)` surfaces in `subscribe_change`'s stream adapter. Operators running databroker with OTel can now alert on subscriber-lag drop rates instead of having to tail warn logs.

The change is gated on the existing `otel` feature flag and is purely additive — behavior with OTel disabled is unchanged.

## Existing behavior

At `databroker/src/broker.rs:1813`, `broadcast::channel(channel_capacity)` creates the subscriber-fanout channel. The `BroadcastStream` adapter at `broker.rs:1848-1857` receives `BroadcastStreamRecvError::Lagged(u64)` on lag and currently:

- logs a `warn!` including the `Display`-formatted error
- returns `None` (which downstream filters out)
- discards the count

`databroker/src/open_telemetry.rs` prior to this PR only contains `init_trace()`. The OTLP metrics pipeline isn't wired: `opentelemetry-otlp` already declares `features = ["tonic", "metrics"]`, but the `opentelemetry` crate was missing `"metrics"` and no `init_metrics()` existed.

## Changes

- **`databroker/Cargo.toml`** — add `"metrics"` to the `opentelemetry` crate features.
- **`databroker/src/open_telemetry.rs`** — add `init_metrics()` that builds a `BasicController` via `opentelemetry_otlp::new_pipeline().metrics(selectors::simple::inexpensive(), cumulative_temporality_selector(), runtime::Tokio)`, registers it as the global meter provider, creates a `u64_counter("broadcast_drops_total")`, and caches it in a `OnceLock`. Add `broadcast_drop_counter()` accessor.
- **`databroker/src/lib.rs`** — call `init_metrics()` in the `otel`-gated `init_logging()` path, after `init_trace()`.
- **`databroker/src/broker.rs`** — import `BroadcastStreamRecvError`; change the `Err(err)` arm to `Err(BroadcastStreamRecvError::Lagged(n))`; increment the counter by `n` inside a `#[cfg(feature = "otel")]` block; keep `None` propagation; tighten the warn message to surface `n` directly (previously `"...lagged and missed signal updates: {err}"`, now `"...lagged, missed {n} signal updates"`).
- **Test**: `test_broadcast_stream_lagged_variant_exposes_drop_count` asserts the destructure pattern on an over-capacity `BroadcastStream`.

## Scope classification

Minor enhancement. No public API surface change. No new feature flag. Behavior identical when `otel` is disabled.

## v0.19 API note

`Counter::add` in `opentelemetry` 0.19 takes `(&Context, value, attributes)` — the issue body suggested the 0.21+ form `counter.add(n, &[])`, which would have compiled with the newer crate but not the pinned one. This PR uses the correct v0.19 signature: `counter.add(&Context::current(), n, &[])`.

## Testing

- `cargo fmt -- --check` — clean
- `cargo clippy --all-targets -- -W warnings -D warnings` — clean
- `cargo clippy --features viss --all-targets -- -W warnings -D warnings` — clean
- `cargo test --lib` — 185/185 pass (184 existing + 1 new regression)
- `cargo test --lib --features otel` — 185/185 pass
- Both `cargo build` and `cargo build --features otel` compile clean

## Relationship to prior work

- [#199](https://github.com/eclipse-kuksa/kuksa-databroker/pull/199) (merged 2026-04-17) established the test-alongside-behavior-change pattern I followed here for the regression test
- [#198](https://github.com/eclipse-kuksa/kuksa-databroker/pull/198) (VISS StreamDeserializer lint fix) confirmed the repo's clippy-strict posture
- [#197](https://github.com/eclipse-kuksa/kuksa-databroker/pull/197) (JWT ES256/EdDSA support) is the pattern I followed for module-level additions inside existing feature-gated modules

The `otel` feature's existing shape (trace-only; `init_trace` in `open_telemetry.rs` wired from `lib.rs::init_logging`) was preserved — metrics init mirrors it exactly.

## Deferred

Per the issue thread, @SebastianSchildt suggested also upgrading OTel dependencies to their latest stable versions. I've kept this PR narrow to the observability change so it reviews on one axis; the dep-version bump will come as a separate follow-up PR.

## AI disclosure

This change was drafted with Claude Opus 4.7 assistance; I authored the design, verified the v0.19 API signatures against the vendored crate source, reviewed all code before commit, and author this PR description.
