### PR TITLE
Fix capitalization in Docker files

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -35,11 +35,11 @@ ENV BUILDTARGET="aarch64-unknown-linux-musl"
 # FROM gcr.io/distroless/base-debian12:debug as target-riscv64
 # However, distroless has no RISCV support yet,
 # (Nov 2023). Using debian unstable for now
-FROM riscv64/debian:sid-slim as target-riscv64
+FROM riscv64/debian:sid-slim AS target-riscv64
 ENV BUILDTARGET="riscv64gc-unknown-linux-gnu"
 
 # Now adding generic parts
-FROM target-$TARGETARCH as target
+FROM target-$TARGETARCH AS target
 ARG TARGETARCH
 
 

--- a/scripts/Dockerfile-cli
+++ b/scripts/Dockerfile-cli
@@ -31,7 +31,7 @@ ENV BUILDTARGET="aarch64-unknown-linux-musl"
 # FROM gcr.io/distroless/base-debian12:debug as target-riscv64
 # However, distorless has no RISCV support yet,
 # (Nov 2023). Using debian unstable for now
-FROM riscv64/debian:sid-slim as target-riscv64
+FROM riscv64/debian:sid-slim AS target-riscv64
 ENV BUILDTARGET="riscv64gc-unknown-linux-gnu"
 
 # Databroker-cli is an interactive cli, thus it can only work correctly
@@ -40,12 +40,12 @@ ENV BUILDTARGET="riscv64gc-unknown-linux-gnu"
 # While writing this, the latest versuion 3.18 does not support riscv yet,
 # but edge does. As we are only getting some config files, this will
 # likely not break
-FROM alpine:edge as terminfo-donor
+FROM alpine:edge AS terminfo-donor
 RUN apk update && apk add ncurses-terminfo-base
 
 
 # Now adding generic parts
-FROM target-$TARGETARCH as target
+FROM target-$TARGETARCH AS target
 ARG TARGETARCH
 
 COPY ./dist/$TARGETARCH/databroker-cli /app/databroker-cli


### PR DESCRIPTION
Fixes FromAsCasing: 'as' and 'FROM' keywords' casing do not match

More info: https://docs.docker.com/go/dockerfile/rule/from-as-casing/