### PR TITLE
Fix race conditon in integration test. Wait for databroker container …

### DIFF
--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -22,6 +22,7 @@ pip install -r "${SCRIPT_DIR}"/requirements.txt
 
 DATABROKER_IMAGE=${DATABROKER_IMAGE:-"ghcr.io/eclipse-kuksa/kuksa-databroker:0.6.1"}
 DATABROKER_ADDRESS=${DATABROKER_ADDRESS:-"127.0.0.1:55555"}
+DATABROKER_STARTUP_TIMEOUT=${DATABROKER_STARTUP_TIMEOUT:-10}
 CONTAINER_PLATFORM=${CONTAINER_PLATFORM:-"linux/amd64"}
 
 VSS_DATA_DIR="$SCRIPT_DIR/../data"
@@ -31,8 +32,32 @@ RUNNING_IMAGE=$(
     docker run -d -v ${VSS_DATA_DIR}:/data -p 55555:55555 --rm  --platform ${CONTAINER_PLATFORM} ${DATABROKER_IMAGE} --metadata data/vss-core/vss_release_6.0.json --insecure
 )
 
-echo "Initial output from container:"
-docker logs ${RUNNING_IMAGE}
+echo "Waiting for databroker startup"
+
+
+BROKER_HOST="${DATABROKER_ADDRESS%:*}"
+BROKER_PORT="${DATABROKER_ADDRESS##*:}"
+
+echo "Waiting up to ${DATABROKER_STARTUP_TIMEOUT}s for databroker on ${BROKER_HOST}:${BROKER_PORT}"
+START_TIME=$(date +%s)
+while true; do
+    if (echo > "/dev/tcp/${BROKER_HOST}/${BROKER_PORT}") >/dev/null 2>&1; then
+        echo "Databroker is reachable on ${BROKER_HOST}:${BROKER_PORT}"
+        docker logs ${RUNNING_IMAGE}
+        break
+    fi
+
+    NOW=$(date +%s)
+    if (( NOW - START_TIME >= DATABROKER_STARTUP_TIMEOUT )); then
+        echo "Timed out waiting for databroker on ${BROKER_HOST}:${BROKER_PORT}"
+        docker logs ${RUNNING_IMAGE}
+        docker stop ${RUNNING_IMAGE}
+        exit 1
+    fi
+
+    sleep 1
+done
+
 
 python3 -m pytest -v "${SCRIPT_DIR}/test_databroker.py"
 


### PR DESCRIPTION
Similar to #215  the python based black box integration tests suffered from the same issue: Sometimes tests where started before the container was up and running (especially for emulated containers such as running riscv via qemu in amd64)

This fixes that, by making sure the TCP socket of databroker is actually available before starting the test code

