### PR TITLE
Upgrade dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,16 +11,16 @@
 # * SPDX-License-Identifier: Apache-2.0
 # ********************************************************************************/
 
-FROM mcr.microsoft.com/devcontainers/rust:1-1-bookworm
+FROM mcr.microsoft.com/devcontainers/rust:2-trixie
 ARG DEBIAN_FRONTEND=noninteractive
 ENV CROSS_CONTAINER_IN_CONTAINER=true
 ENV TZ=Europe/Berlin
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN apt-get update -y
-RUN apt install software-properties-common build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev curl git libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev -y
+RUN apt install  build-essential  cmake    libreadline-dev  curl git   -y
 
 USER vscode
-RUN cargo install cross cargo-license cargo-cyclonedx
+RUN cargo install cross cargo-license cargo-cyclonedx cargo-llvm-cov
 
 # Installing pyEnv to set up specific version of Python
 ENV HOME=/home/vscode

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,9 @@
 		"dockerfile": "Dockerfile"
 	},
 	"features": {
-		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
+		"ghcr.io/devcontainers/features/docker-in-docker:4.0.0": {
+			"moby": "false" //we are using debian trixie base image, which does not support OSS moby, so using docker-ce instead
+		}
 	},
 	"postStartCommand": "bash .devcontainer/postStartCommand.sh",
 	"mounts": [


### PR DESCRIPTION
I noticed the dev container was missing some components to build current databroker, and the rust version was too old to build/use the coverage tests.

So this is a dump of my local changes

- Moved to current version of the rust decvontainer
- add missing components (e.g. cmake used during prototyping comilation and llvm-cov package for cargo
- Removed some packages that seemed unneccesary


This "works for me", but maybe @mikehaller as our resident dev container fan, you could give it a try?