### PR TITLE
WIP Gracefully handle empty provider response

### DIFF
--- a/databroker/src/broker.rs
+++ b/databroker/src/broker.rs
@@ -2234,7 +2234,23 @@ impl AuthorizedAccess<'_, '_> {
                 //Step 4: collect responses from providers
                 match response {
                     Ok(value) => {
-                        entries_response.extend(value.entries);
+                        if value.entries.is_empty() {
+                            // Provider returned Ok but with no matching entries,
+                            // fall back to database for the requested signals
+                            debug!(
+                                "Provider returned Ok with empty entries, falling back to database"
+                            );
+                            for signal_id in &intersection_signals_request {
+                                match self.get_datapoint(signal_id.id()).await {
+                                    Ok(datapoint) => {
+                                        entries_response.insert(*signal_id, datapoint.clone());
+                                    }
+                                    Err(err) => return Err((err, signal_id.id())),
+                                }
+                            }
+                        } else {
+                            entries_response.extend(value.entries);
+                        }
                     }
                     Err(_) => {
                         //Step 5: if provider did not return any item, then return the datapoint in database

--- a/databroker/src/grpc/kuksa_val_v2/val.rs
+++ b/databroker/src/grpc/kuksa_val_v2/val.rs
@@ -3777,7 +3777,6 @@ mod tests {
         let broker = DataBroker::new(version, commit_hash);
 
         let request = tonic::Request::new(proto::GetServerInfoRequest {});
-
         match proto::val_server::Val::get_server_info(&broker, request)
             .await
             .map(|res| res.into_inner())
@@ -3789,6 +3788,85 @@ mod tests {
             }
             Err(_) => {
                 panic!("Should not happen")
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_value_returns_error_on_empty_provider_response() {
+        use crate::types::SignalId as TypesSignalId;
+
+        struct EmptyResponseProvider;
+
+        #[async_trait::async_trait]
+        impl SignalProvider for EmptyResponseProvider {
+            async fn update_filter(
+                &self,
+                _update_fiters: HashMap<TypesSignalId, Option<TimeInterval>>,
+            ) -> Result<(), (RegisterSignalError, String)> {
+                Ok(())
+            }
+
+            fn is_available(&self) -> bool {
+                true
+            }
+
+            async fn get_signals_values_from_provider(
+                &mut self,
+                _signals_ids: Vec<TypesSignalId>,
+            ) -> Result<GetValuesProviderResponse, ()> {
+                Ok(GetValuesProviderResponse {
+                    entries: IndexMap::new(),
+                })
+            }
+        }
+
+        let broker = DataBroker::default();
+        let timestamp = std::time::SystemTime::now();
+
+        let entry_id = broker::tests::helper_add_int32(&broker, "test.empty", 42, timestamp)
+            .await
+            .expect("Shall succeed");
+
+        let auth_broker = broker.authorized_access(&permissions::ALLOW_ALL);
+
+        let mock = EmptyResponseProvider;
+
+        let mut intervals = HashMap::new();
+        intervals.insert(TypesSignalId::new(entry_id), TimeInterval::new(0));
+
+        auth_broker
+            .register_signals(intervals, Box::new(mock))
+            .await
+            .expect("Register signals should succeed");
+
+        let request = proto::GetValueRequest {
+            signal_id: Some(proto::SignalId {
+                signal: Some(proto::signal_id::Signal::Id(entry_id)),
+            }),
+        };
+
+        let mut get_value_request = tonic::Request::new(request);
+        get_value_request
+            .extensions_mut()
+            .insert(permissions::ALLOW_ALL.clone());
+
+        let join_handle = tokio::spawn(async move { broker.get_value(get_value_request).await });
+
+        match join_handle.await {
+            Ok(response) => {
+                assert!(
+                    response.is_err(),
+                    "Expected gRPC error when provider returns empty entries, got Ok"
+                );
+            }
+            Err(join_error) => {
+                if join_error.is_panic() {
+                    panic!(
+                        "BUG: get_value panicked on empty provider response instead of returning a gRPC error"
+                    );
+                }
+                panic!("get_value task was cancelled: {}", join_error);
             }
         }
     }

--- a/databroker/src/grpc/kuksa_val_v2/val.rs
+++ b/databroker/src/grpc/kuksa_val_v2/val.rs
@@ -177,6 +177,11 @@ impl SignalProvider for Provider {
                             for (id, datapoint) in value.entries {
                                 entries_map.insert(SignalId::new(id), (&datapoint).into());
                             }
+                            // Reject empty response from provider to trigger fallback to database
+                            if entries_map.is_empty() {
+                                debug!("Provider returned empty entries, falling back to database");
+                                return Err(());
+                            }
                             return Ok(GetValuesProviderResponse {
                                 entries: entries_map,
                             });
@@ -234,9 +239,18 @@ impl proto::val_server::Val for broker::DataBroker {
             }
         };
 
-        Ok(tonic::Response::new(proto::GetValueResponse {
-            data_point: datapoint.entries.values().next().unwrap().clone().into(),
-        }))
+        let data_point = match datapoint.entries.values().next() {
+            Some(dp) => dp.clone().into(),
+            // Defensive: should not be reached after provider fallback to database,
+            // but protects against panics if entries is unexpectedly empty
+            None => {
+                return Err(tonic::Status::internal(format!(
+                    "No value available for requested signal (id: {})",
+                    signal_id.id()
+                )))
+            }
+        };
+        Ok(tonic::Response::new(proto::GetValueResponse { data_point }))
     }
 
     // Returns (GRPC error code):
@@ -3855,9 +3869,14 @@ mod tests {
 
         match join_handle.await {
             Ok(response) => {
+                // Empty provider response is rejected (Fix A), triggering
+                // database fallback in get_values_broker. The entry was populated
+                // via helper_add_int32, so the fallback succeeds.
+                let get_response = response.expect("get_value should succeed via DB fallback");
+                let data_point = get_response.into_inner().data_point;
                 assert!(
-                    response.is_err(),
-                    "Expected gRPC error when provider returns empty entries, got Ok"
+                    data_point.is_some(),
+                    "data_point should be present via DB fallback"
                 );
             }
             Err(join_error) => {


### PR DESCRIPTION
Part of fixing #221 

This fixes the issue that an Empty provider Response triggers a panic.
(The other issue in #221 will be investigated and fixed separately)

Old logic for v2 API
 - A request for data is forwarded to a provider
 - If a provider provides data points they are forwarded to the caller
 - If a provider errors, the database is queried for the latest data


The issue:
 - If a provider returns "ok" but the response is empty, a panic can occur when databroker tries to unpack the none existing data (I think it is not clearly defined whether this is "correct" behavior of a provider but it might make sense for a provider when queried to say "I am here, but I have nt current data", in any way databroker should be robust against it)


The new logic:
  - We check for an empty response and handle it similarly as an error, i.e. trying the database feedback 

There also is a new unit test. The test has been fully AI generated... But I verified it triggers with the old logic, and passes now that the fix is in.

