### PR TITLE
Update to new clippy rules (1.97)

### DIFF
--- a/databroker-cli/src/kuksa_cli.rs
+++ b/databroker-cli/src/kuksa_cli.rs
@@ -535,14 +535,14 @@ pub async fn kuksa_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                                                                 write!(
                                                                     output,
                                                                     "{} ",
-                                                                    &sub_disp_color,
+                                                                    sub_disp_color,
                                                                 )
                                                                 .unwrap();
                                                             } else {
                                                                 write!(
                                                                     output,
                                                                     "{} ",
-                                                                    &sub_disp_pad,
+                                                                    sub_disp_pad,
                                                                 )
                                                                 .unwrap();
                                                             }
@@ -586,7 +586,7 @@ pub async fn kuksa_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                                                     write!(
                                                         iface,
                                                         "{} {}",
-                                                        &sub_disp_color,
+                                                        sub_disp_color,
                                                         Color::Red
                                                             .dimmed()
                                                             .paint(format!("Channel error: {err}"))

--- a/databroker/src/broker.rs
+++ b/databroker/src/broker.rs
@@ -2203,7 +2203,7 @@ impl AuthorizedAccess<'_, '_> {
         // if there are providers connected then forward the get value request to them
         if !subscriptions.signal_provider_subscriptions.is_empty() {
             // Step 1: find the interseccion of the requested signals and each provider's signals
-            for (_, provider) in subscriptions.signal_provider_subscriptions.iter_mut() {
+            for provider in subscriptions.signal_provider_subscriptions.values_mut() {
                 let intersection_signals_request: Vec<SignalId> = provider
                     .vss_ids
                     .intersection(&vss_signals.clone().into_iter().collect())
@@ -2320,7 +2320,7 @@ impl DataBroker {
 
                         // check which subscription contains a signal of the closed providers:
                         for (_, provider_signals_set) in closed_signal_providers {
-                            for (_, subscription) in remaining_subscriptions.iter_mut() {
+                            for subscription in remaining_subscriptions.values_mut() {
                                 let subscription_key_set: HashSet<_> =
                                     subscription.entries.keys().cloned().collect();
 

--- a/databroker/src/grpc/kuksa_val_v2/val.rs
+++ b/databroker/src/grpc/kuksa_val_v2/val.rs
@@ -906,15 +906,15 @@ impl proto::val_server::Val for broker::DataBroker {
                                                             if let Some(signal_id) = batch_actuate_stream_response.signal_id {
                                                                 match signal_id.signal {
                                                                     Some(proto::signal_id::Signal::Path(path)) => {
-                                                                        msg = format!("{}, path: {}", msg, &path);
+                                                                        msg = format!("{}, path: {}", msg, path);
                                                                     }
                                                                     Some(proto::signal_id::Signal::Id(id)) => {
-                                                                        msg = format!("{}, id: {}",msg, &id.to_string());
+                                                                        msg = format!("{}, id: {}",msg, id);
                                                                     }
                                                                     None => {}
                                                                 }
                                                             }
-                                                            msg = format!("{}, error code: {}, error message: {}", msg, &error.code.to_string(), &error.message);
+                                                            msg = format!("{}, error code: {}, error message: {}", msg, error.code, error.message);
                                                             debug!(msg)
                                                         }
                                                     }


### PR DESCRIPTION
There are some new clippy best practices (1.97)

Apply them, as currently CI will fail e.g. see PR #222

The fixes are
 https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#for_kv_map
https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#useless_borrows_in_formatting
https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#to_string_in_format_args


