### PR TITLE
Add early panic with clear message for streaming buffer

### DIFF
--- a/databroker/src/grpc/kuksa_val_v1/val.rs
+++ b/databroker/src/grpc/kuksa_val_v1/val.rs
@@ -1169,9 +1169,14 @@ mod tests {
         let mut buf = BytesMut::new();
         for msg in &messages {
             let encoded = msg.encode_to_vec();
-            buf.reserve(5 + encoded.len());
+            let frame_len = encoded
+                .len()
+                .checked_add(5)
+                .expect("Streaming frame length overflow");
+            buf.reserve(frame_len);
             buf.put_u8(0); // no compression
-            buf.put_u32(encoded.len() as u32);
+            let encoded_len = u32::try_from(encoded.len()).expect("Encoded message too large");
+            buf.put_u32(encoded_len);
             buf.extend_from_slice(&encoded);
         }
 

--- a/databroker/src/grpc/kuksa_val_v2/val.rs
+++ b/databroker/src/grpc/kuksa_val_v2/val.rs
@@ -1361,9 +1361,14 @@ mod tests {
         let mut buf = BytesMut::new();
         for msg in &messages {
             let encoded = msg.encode_to_vec();
-            buf.reserve(5 + encoded.len());
+            let frame_len = encoded
+                .len()
+                .checked_add(5)
+                .expect("Streaming frame length overflow");
+            buf.reserve(frame_len);
             buf.put_u8(0); // no compression
-            buf.put_u32(encoded.len() as u32);
+            let encoded_len = u32::try_from(encoded.len()).expect("Encoded message too large");
+            buf.put_u32(encoded_len);
             buf.extend_from_slice(&encoded);
         }
 


### PR DESCRIPTION
Adds early overflow checking before calling into BytesMut::reserve so we don't run into [RUSTSEC-2026-0007](https://rustsec.org/advisories/RUSTSEC-2026-0007.html) during tests.

> In the unique reclaim path of BytesMut::reserve, the condition
> 
> `if v_capacity >= new_cap + offset`
> 
> uses an unchecked addition. When new_cap + offset overflows usize in release builds, this condition may incorrectly pass, causing self.cap to be set to a value that exceeds the actual allocated capacity. Subsequent APIs such as spare_capacity_mut() then trust this corrupted cap value and may create out-of-bounds slices, leading to UB.
> 
> This behavior is observable in release builds (integer overflow wraps), whereas debug builds panic due to overflow checks.