### PR TITLE
Fix processing of invalid/delayed provider responses

### DIFF
--- a/databroker/src/grpc/kuksa_val_v2/val.rs
+++ b/databroker/src/grpc/kuksa_val_v2/val.rs
@@ -3889,4 +3889,149 @@ mod tests {
             }
         }
     }
+
+    // ---- Provider response correlation (request_id / signal_id) tests ----
+
+    use crate::types::SignalId as TypesSignalId;
+
+    /// Helper: builds a Datapoint with a float value for use in broadcast response entries
+    fn make_float_datapoint(value: f32) -> proto::Datapoint {
+        proto::Datapoint {
+            timestamp: Some(std::time::SystemTime::now().into()),
+            value: Some(proto::Value {
+                typed_value: Some(proto::value::TypedValue::Float(value)),
+            }),
+        }
+    }
+
+    /// Creates a Provider directly for tests that control the broadcast receiver
+    fn make_provider_with_broadcast_rx(
+    ) -> (Provider, broadcast::Sender<proto::GetProviderValueResponse>) {
+        let (mpsc_tx, _mpsc_rx) =
+            mpsc::channel::<Result<OpenProviderStreamResponse, tonic::Status>>(10);
+        let (broadcast_tx, broadcast_rx) =
+            broadcast::channel::<proto::GetProviderValueResponse>(10);
+        let provider = Provider {
+            sender: mpsc_tx,
+            receiver: Some(BroadcastStream::new(broadcast_rx)),
+        };
+        (provider, broadcast_tx)
+    }
+
+    #[tokio::test]
+    async fn test_provider_correct_response_accepted() {
+        let our_signal = 1;
+        let (mut provider, broadcast_tx) = make_provider_with_broadcast_rx();
+
+        let mut entries = HashMap::new();
+        entries.insert(our_signal, make_float_datapoint(12.5));
+
+        // Response with matching request_id and correct signal
+        let _ = broadcast_tx.send(proto::GetProviderValueResponse {
+            request_id: 0,
+            entries,
+        });
+
+        let result = provider
+            .get_signals_values_from_provider(vec![TypesSignalId::new(our_signal)])
+            .await;
+
+        let response = result.expect("correct request_id and signal_id should be accepted");
+        let returned = response
+            .entries
+            .get(&TypesSignalId::new(our_signal))
+            .expect("returned entries should contain our signal");
+        assert_eq!(returned.value, DataValue::Float(12.5));
+    }
+
+    #[tokio::test]
+    async fn test_provider_wrong_request_id_discarded_via_timeout() {
+        let our_signal = 1;
+        let (mut provider, broadcast_tx) = make_provider_with_broadcast_rx();
+
+        let mut entries = HashMap::new();
+        entries.insert(our_signal, make_float_datapoint(99.0));
+
+        // Response with wrong request_id=999 — filter should skip it, then 1s timeout
+        let _ = broadcast_tx.send(proto::GetProviderValueResponse {
+            request_id: 999,
+            entries,
+        });
+
+        // Outer timeout guards the test against hanging if the fix isn't in place
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(3),
+            provider.get_signals_values_from_provider(vec![TypesSignalId::new(our_signal)]),
+        )
+        .await;
+
+        let timed_out = result.expect("inner call should complete (not hang)");
+        assert!(
+            timed_out.is_err(),
+            "wrong request_id should be discarded and call should time out, but got Ok instead"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_provider_wrong_signal_id_discarded() {
+        let other_signal = 999;
+        let our_signal = 1;
+        let (mut provider, broadcast_tx) = make_provider_with_broadcast_rx();
+
+        let mut entries = HashMap::new();
+        entries.insert(other_signal, make_float_datapoint(99.0));
+
+        // Response with matching request_id=0 but entries for a different signal
+        let _ = broadcast_tx.send(proto::GetProviderValueResponse {
+            request_id: 0,
+            entries,
+        });
+
+        let result = provider
+            .get_signals_values_from_provider(vec![TypesSignalId::new(our_signal)])
+            .await;
+
+        assert!(
+            result.is_err(),
+            "response with only non-requested signal IDs should be discarded, but got Ok instead"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_provider_skips_wrong_request_id_then_accepts_correct() {
+        let other_signal = 999;
+        let our_signal = 1;
+        let (mut provider, broadcast_tx) = make_provider_with_broadcast_rx();
+
+        // First response: wrong request_id — should be skipped
+        let mut wrong_entries = HashMap::new();
+        wrong_entries.insert(other_signal, make_float_datapoint(99.0));
+        let _ = broadcast_tx.send(proto::GetProviderValueResponse {
+            request_id: 999,
+            entries: wrong_entries,
+        });
+
+        // Second response: correct request_id and correct signal — should be accepted
+        let mut correct_entries = HashMap::new();
+        correct_entries.insert(our_signal, make_float_datapoint(12.5));
+        let _ = broadcast_tx.send(proto::GetProviderValueResponse {
+            request_id: 0,
+            entries: correct_entries,
+        });
+
+        let result = provider
+            .get_signals_values_from_provider(vec![TypesSignalId::new(our_signal)])
+            .await;
+
+        let response = result.expect("should have accepted the second (matching) response");
+        let returned = response
+            .entries
+            .get(&TypesSignalId::new(our_signal))
+            .expect("returned entries should contain our signal");
+        assert_eq!(
+            returned.value,
+            DataValue::Float(12.5),
+            "should receive 12.5 from second response, not 99.0 from the discarded first"
+        );
+    }
 }

--- a/databroker/src/grpc/kuksa_val_v2/val.rs
+++ b/databroker/src/grpc/kuksa_val_v2/val.rs
@@ -55,6 +55,7 @@ const MAX_REQUEST_PATH_LENGTH: usize = 1000;
 pub struct Provider {
     sender: mpsc::Sender<Result<OpenProviderStreamResponse, tonic::Status>>,
     receiver: Option<BroadcastStream<databroker_proto::kuksa::val::v2::GetProviderValueResponse>>,
+    next_request_id: u32,
 }
 
 #[async_trait::async_trait]
@@ -149,11 +150,14 @@ impl SignalProvider for Provider {
         &mut self,
         signals_ids: Vec<SignalId>,
     ) -> Result<GetValuesProviderResponse, ()> {
+        let request_id = self.next_request_id;
+        self.next_request_id = self.next_request_id.wrapping_add(1);
+
         let request = OpenProviderStreamResponse {
             action: Some(
                 open_provider_stream_response::Action::GetProviderValueRequest(
                     proto::GetProviderValueRequest {
-                        request_id: 0,
+                        request_id,
                         signal_ids: signals_ids.iter().map(|signal_id| signal_id.id()).collect(),
                     },
                 ),
@@ -167,32 +171,54 @@ impl SignalProvider for Provider {
                 debug!("{}", err.to_string());
             }
         }
-        match self.receiver.as_mut() {
-            // Here is assumed that provider will return a response immediately, todo -> timeout configuration
-            Some(receiver) => {
-                match timeout(tokio::time::Duration::from_secs(1), receiver.next()).await {
-                    Ok(Some(value)) => match value {
-                        Ok(value) => {
-                            let mut entries_map = IndexMap::new();
-                            for (id, datapoint) in value.entries {
-                                entries_map.insert(SignalId::new(id), (&datapoint).into());
-                            }
-                            // Reject empty response from provider to trigger fallback to database
-                            if entries_map.is_empty() {
-                                debug!("Provider returned empty entries, falling back to database");
-                                return Err(());
-                            }
-                            return Ok(GetValuesProviderResponse {
-                                entries: entries_map,
-                            });
-                        }
-                        Err(_) => Err(()),
-                    },
-                    // Either the stream ended (None) or the timeout elapsed (Err).
-                    Ok(None) | Err(_) => Err(()),
-                }
+
+        let receiver = match self.receiver.as_mut() {
+            Some(receiver) => receiver,
+            None => return Err(()),
+        };
+
+        let deadline = std::time::Instant::now() + tokio::time::Duration::from_secs(1);
+        // Collect requested IDs for filtering provider response entries
+        let requested_ids: HashSet<i32> = signals_ids.iter().map(|id| id.id()).collect();
+
+        loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            if remaining.is_zero() {
+                return Err(());
             }
-            None => Err(()),
+
+            match timeout(remaining, receiver.next()).await {
+                Ok(Some(Ok(response))) => {
+                    if response.request_id != request_id {
+                        debug!(
+                            "Skipping provider response with unexpected request_id {} (expected {})",
+                            response.request_id, request_id
+                        );
+                        continue;
+                    }
+
+                    // Only accept entries for the signals we actually requested
+                    let mut entries_map = IndexMap::new();
+                    for (id, datapoint) in response.entries {
+                        if requested_ids.contains(&id) {
+                            entries_map.insert(SignalId::new(id), (&datapoint).into());
+                        }
+                    }
+
+                    // Reject empty response from provider to trigger fallback to database
+                    if entries_map.is_empty() {
+                        debug!("Provider returned empty entries, falling back to database");
+                        return Err(());
+                    }
+
+                    return Ok(GetValuesProviderResponse {
+                        entries: entries_map,
+                    });
+                }
+                Ok(Some(Err(_))) => return Err(()),
+                // Either the stream ended (None) or the timeout elapsed (Err).
+                Ok(None) | Err(_) => return Err(()),
+            }
         }
     }
 }
@@ -242,7 +268,7 @@ impl proto::val_server::Val for broker::DataBroker {
         let data_point = match datapoint.entries.values().next() {
             Some(dp) => dp.clone().into(),
             // Defensive: should not be reached after provider fallback to database,
-            // but protects against panics if entries is unexpectedly empty
+            // but protects against panics if the requested signal is missing
             None => {
                 return Err(tonic::Status::internal(format!(
                     "No value available for requested signal (id: {})",
@@ -1084,6 +1110,7 @@ async fn provide_actuation(
     let provider = Provider {
         sender,
         receiver: None,
+        next_request_id: 1,
     };
 
     match broker
@@ -1117,6 +1144,7 @@ async fn register_provided_signals(
     let provider = Provider {
         sender,
         receiver: Some(BroadcastStream::new(receiver)),
+        next_request_id: 1,
     };
 
     let all_vss_ids = request
@@ -2971,6 +2999,7 @@ mod tests {
         let actuation_provider = Provider {
             sender,
             receiver: None,
+            next_request_id: 1,
         };
         authorized_access
             .provide_actuation(vss_ids, Box::new(actuation_provider))
@@ -3097,6 +3126,7 @@ mod tests {
         let actuation_provider = Provider {
             sender,
             receiver: None,
+            next_request_id: 1,
         };
         authorized_access
             .provide_actuation(vss_ids, Box::new(actuation_provider))
@@ -3198,6 +3228,7 @@ mod tests {
         let actuation_provider = Provider {
             sender,
             receiver: None,
+            next_request_id: 1,
         };
         authorized_access
             .provide_actuation(vss_ids, Box::new(actuation_provider))
@@ -3351,6 +3382,7 @@ mod tests {
         let actuation_provider = Provider {
             sender,
             receiver: None,
+            next_request_id: 1,
         };
         authorized_access
             .provide_actuation(vss_ids, Box::new(actuation_provider))
@@ -3444,6 +3476,7 @@ mod tests {
         let actuation_provider = Provider {
             sender,
             receiver: None,
+            next_request_id: 1,
         };
         authorized_access
             .provide_actuation(vss_ids, Box::new(actuation_provider))
@@ -3614,6 +3647,7 @@ mod tests {
         let actuation_provider = Provider {
             sender,
             receiver: None,
+            next_request_id: 1,
         };
         authorized_access
             .provide_actuation(vss_ids, Box::new(actuation_provider))
@@ -3752,6 +3786,7 @@ mod tests {
         let actuation_provider = Provider {
             sender,
             receiver: None,
+            next_request_id: 1,
         };
         authorized_access
             .provide_actuation(vss_ids, Box::new(actuation_provider))
@@ -3914,6 +3949,7 @@ mod tests {
         let provider = Provider {
             sender: mpsc_tx,
             receiver: Some(BroadcastStream::new(broadcast_rx)),
+            next_request_id: 1,
         };
         (provider, broadcast_tx)
     }
@@ -3928,7 +3964,7 @@ mod tests {
 
         // Response with matching request_id and correct signal
         let _ = broadcast_tx.send(proto::GetProviderValueResponse {
-            request_id: 0,
+            request_id: 1,
             entries,
         });
 
@@ -3960,7 +3996,7 @@ mod tests {
 
         // Outer timeout guards the test against hanging if the fix isn't in place
         let result = tokio::time::timeout(
-            std::time::Duration::from_secs(3),
+            std::time::Duration::from_secs(2),
             provider.get_signals_values_from_provider(vec![TypesSignalId::new(our_signal)]),
         )
         .await;
@@ -3981,9 +4017,9 @@ mod tests {
         let mut entries = HashMap::new();
         entries.insert(other_signal, make_float_datapoint(99.0));
 
-        // Response with matching request_id=0 but entries for a different signal
+        // Response with matching request_id but entries for a different signal
         let _ = broadcast_tx.send(proto::GetProviderValueResponse {
-            request_id: 0,
+            request_id: 1,
             entries,
         });
 
@@ -4015,7 +4051,7 @@ mod tests {
         let mut correct_entries = HashMap::new();
         correct_entries.insert(our_signal, make_float_datapoint(12.5));
         let _ = broadcast_tx.send(proto::GetProviderValueResponse {
-            request_id: 0,
+            request_id: 1,
             entries: correct_entries,
         });
 


### PR DESCRIPTION
This should fix #221 

When a provider's response to request A arrived after request A had timed out, it could be consumed by request B, which was waiting on the same provider connection. 

Issues:
1. request_id was hardcoded to 0 for every GetProviderValueRequest, making it impossible to match a response to its originating request.
2. Shared broadcast channel — every get_signals_values_from_provider call subscribed to the same broadcast::Receiver. A response for any request was delivered to all concurrent waiters with no correlation.
3. No signal ID validation — get_value took the first map entry blindly (entries.values().next().unwrap()) without checking it matched the requested signal.

Fix
1. Provider struct — added next_request_id: u32 field, initialized to 1
2. get_signals_values_from_provider — added checks:
    - Send GetProviderValueRequest with a unique, incrementing request_id
    - Loop on the broadcast receiver with a 1s total deadline
    - Skips responses whose request_id doesn't match 
    - Filters entries to only include signal IDs present in the original request
    - Returns Err(()) if no matching entries remain (triggers existing DB fallback)

Also added some unit tests verifying correct processing of wrong replies