### PR TITLE
Make sure blocking/slow providers can not DDOS us

### DIFF
--- a/databroker/src/broker.rs
+++ b/databroker/src/broker.rs
@@ -36,6 +36,7 @@ use tracing::{debug, info, warn};
 use crate::glob;
 
 const MAX_SUBSCRIBE_BUFFER_SIZE: usize = 1000;
+const PROVIDER_UPDATE_FILTER_TIMEOUT: Duration = Duration::from_secs(1);
 
 #[derive(Debug)]
 pub enum ActuationError {
@@ -2200,7 +2201,7 @@ impl AuthorizedAccess<'_, '_> {
         &self,
         vss_signals: Vec<SignalId>,
     ) -> Result<GetValuesProviderResponse, (ReadError, i32)> {
-        let mut entries_response: IndexMap<SignalId, Datapoint> = IndexMap::new();
+        let mut collected_entries: IndexMap<SignalId, Datapoint> = IndexMap::new();
         let requested_signals: HashSet<SignalId> = vss_signals.iter().copied().collect();
 
         // Snapshot the providers and the signals they can serve. The
@@ -2263,13 +2264,13 @@ impl AuthorizedAccess<'_, '_> {
                         for signal_id in &intersection_signals_request {
                             match self.get_datapoint(signal_id.id()).await {
                                 Ok(datapoint) => {
-                                    entries_response.insert(*signal_id, datapoint.clone());
+                                    collected_entries.insert(*signal_id, datapoint.clone());
                                 }
                                 Err(err) => return Err((err, signal_id.id())),
                             }
                         }
                     } else {
-                        entries_response.extend(value.entries);
+                        collected_entries.extend(value.entries);
                     }
                 }
                 Err(_) => {
@@ -2277,7 +2278,7 @@ impl AuthorizedAccess<'_, '_> {
                     for signal_id in &intersection_signals_request {
                         match self.get_datapoint(signal_id.id()).await {
                             Ok(datapoint) => {
-                                entries_response.insert(*signal_id, datapoint.clone());
+                                collected_entries.insert(*signal_id, datapoint.clone());
                             }
                             Err(err) => return Err((err, signal_id.id())),
                         }
@@ -2293,9 +2294,19 @@ impl AuthorizedAccess<'_, '_> {
             }
             match self.get_datapoint(signal_id.id()).await {
                 Ok(datapoint) => {
-                    entries_response.insert(*signal_id, datapoint.clone());
+                    collected_entries.insert(*signal_id, datapoint.clone());
                 }
                 Err(err) => return Err((err, signal_id.id())),
+            }
+        }
+
+        // Preserve request order: the gRPC contract promises that data points
+        // are returned in the same order as the requested signals.
+        let mut entries_response: IndexMap<SignalId, Datapoint> =
+            IndexMap::with_capacity(vss_signals.len());
+        for signal_id in &vss_signals {
+            if let Some(datapoint) = collected_entries.get(signal_id) {
+                entries_response.insert(*signal_id, datapoint.clone());
             }
         }
 
@@ -2441,12 +2452,24 @@ impl DataBroker {
                 })
                 .collect();
 
-            // Send to each provider the new (signal_id, new_interval) map.
+            // Send to each provider the new (signal_id, new_interval) map. Bound
+            // the call so a hung provider cannot stop housekeeping or delay the
+            // remaining providers indefinitely.
             if !update_signal_map.is_empty() {
-                signal_provider
-                    .update_filter(update_signal_map)
-                    .await
-                    .unwrap();
+                match tokio::time::timeout(
+                    PROVIDER_UPDATE_FILTER_TIMEOUT,
+                    signal_provider.update_filter(update_signal_map),
+                )
+                .await
+                {
+                    Ok(Ok(())) => {}
+                    Ok(Err((error, message))) => {
+                        warn!("Failed to update filter for provider: {error:?}: {message}");
+                    }
+                    Err(_) => {
+                        warn!("Timed out updating filter for provider");
+                    }
+                }
             }
         }
     }
@@ -5302,6 +5325,214 @@ pub mod tests {
         assert!(
             result.is_ok(),
             "subscriptions operations blocked while an actuation provider was pending"
+        );
+    }
+
+    struct StaticValueProvider {
+        signal_id: SignalId,
+        value: DataValue,
+    }
+
+    #[async_trait::async_trait]
+    impl SignalProvider for StaticValueProvider {
+        async fn update_filter(
+            &self,
+            _update_filters: HashMap<SignalId, Option<TimeInterval>>,
+        ) -> Result<(), (RegisterSignalError, String)> {
+            Ok(())
+        }
+
+        fn is_available(&self) -> bool {
+            true
+        }
+
+        async fn get_signals_values_from_provider(
+            &self,
+            _signals_ids: Vec<SignalId>,
+        ) -> Result<GetValuesProviderResponse, ()> {
+            let mut entries = IndexMap::new();
+            entries.insert(
+                self.signal_id,
+                Datapoint {
+                    ts: std::time::SystemTime::now(),
+                    source_ts: None,
+                    value: self.value.clone(),
+                },
+            );
+            Ok(GetValuesProviderResponse { entries })
+        }
+    }
+
+    struct FailingUpdateFilterProvider;
+
+    #[async_trait::async_trait]
+    impl SignalProvider for FailingUpdateFilterProvider {
+        async fn update_filter(
+            &self,
+            _update_filters: HashMap<SignalId, Option<TimeInterval>>,
+        ) -> Result<(), (RegisterSignalError, String)> {
+            Err((
+                RegisterSignalError::TransmissionFailure,
+                "provider is gone".to_string(),
+            ))
+        }
+
+        fn is_available(&self) -> bool {
+            true
+        }
+
+        async fn get_signals_values_from_provider(
+            &self,
+            _signals_ids: Vec<SignalId>,
+        ) -> Result<GetValuesProviderResponse, ()> {
+            Err(())
+        }
+    }
+
+    struct CountingUpdateFilterProvider {
+        calls: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl SignalProvider for CountingUpdateFilterProvider {
+        async fn update_filter(
+            &self,
+            _update_filters: HashMap<SignalId, Option<TimeInterval>>,
+        ) -> Result<(), (RegisterSignalError, String)> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        fn is_available(&self) -> bool {
+            true
+        }
+
+        async fn get_signals_values_from_provider(
+            &self,
+            _signals_ids: Vec<SignalId>,
+        ) -> Result<GetValuesProviderResponse, ()> {
+            Err(())
+        }
+    }
+
+    /// The gRPC contract promises data points in request order. A mixed request
+    /// (database-only signal first, provider signal second) must not be
+    /// reordered by the provider/database merge.
+    #[tokio::test]
+    async fn test_get_values_preserves_request_order() {
+        let broker = DataBroker::default();
+        let timestamp = std::time::SystemTime::now();
+
+        let provided_signal = helper_add_int32(&broker, "test.provided", 1, timestamp)
+            .await
+            .expect("add provided signal");
+        let db_signal = helper_add_int32(&broker, "test.db", 2, timestamp)
+            .await
+            .expect("add db signal");
+
+        let auth = broker.authorized_access(&permissions::ALLOW_ALL);
+        auth.register_signals(
+            HashMap::from([(SignalId::new(provided_signal), TimeInterval::new(0))]),
+            Box::new(StaticValueProvider {
+                signal_id: SignalId::new(provided_signal),
+                value: DataValue::Int32(7),
+            }),
+        )
+        .await
+        .expect("register provider");
+
+        let response = auth
+            .get_values_broker(vec![
+                SignalId::new(db_signal),
+                SignalId::new(provided_signal),
+            ])
+            .await
+            .expect("get values should succeed");
+
+        let ordered_signals: Vec<SignalId> = response.entries.keys().copied().collect();
+        assert_eq!(
+            ordered_signals,
+            vec![SignalId::new(db_signal), SignalId::new(provided_signal)],
+            "data points must follow request order"
+        );
+        assert_eq!(
+            response
+                .entries
+                .get(&SignalId::new(db_signal))
+                .expect("db signal present")
+                .value,
+            DataValue::Int32(2)
+        );
+        assert_eq!(
+            response
+                .entries
+                .get(&SignalId::new(provided_signal))
+                .expect("provided signal present")
+                .value,
+            DataValue::Int32(7)
+        );
+    }
+
+    /// A provider returning an error from `update_filter` must not panic the
+    /// caller, and later providers must still receive their filter update.
+    #[tokio::test]
+    async fn test_update_filter_to_providers_continues_after_provider_error() {
+        let signal = SignalId::new(1);
+        let update_intervals = HashMap::from([(signal, Some(TimeInterval::new(0)))]);
+        let failing: Arc<dyn SignalProvider> = Arc::new(FailingUpdateFilterProvider);
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let counting: Arc<dyn SignalProvider> = Arc::new(CountingUpdateFilterProvider {
+            calls: calls.clone(),
+        });
+
+        DataBroker::update_filter_to_providers(
+            update_intervals,
+            vec![
+                (failing, HashSet::from([signal])),
+                (counting, HashSet::from([signal])),
+            ],
+        )
+        .await;
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "later provider must still be updated after a failing provider"
+        );
+    }
+
+    /// A provider whose `update_filter` never returns must not stop the
+    /// propagation to later providers or the housekeeping loop.
+    #[tokio::test]
+    async fn test_update_filter_to_providers_bounds_hanging_provider() {
+        let signal = SignalId::new(1);
+        let update_intervals = HashMap::from([(signal, Some(TimeInterval::new(0)))]);
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let hanging: Arc<dyn SignalProvider> = Arc::new(HangingUpdateFilterProvider {
+            entered: entered.clone(),
+        });
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let counting: Arc<dyn SignalProvider> = Arc::new(CountingUpdateFilterProvider {
+            calls: calls.clone(),
+        });
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(3),
+            DataBroker::update_filter_to_providers(
+                update_intervals,
+                vec![
+                    (hanging, HashSet::from([signal])),
+                    (counting, HashSet::from([signal])),
+                ],
+            ),
+        )
+        .await
+        .expect("hanging provider must not block filter propagation indefinitely");
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "later provider must still be updated after a hanging provider"
         );
     }
 }

--- a/databroker/src/broker.rs
+++ b/databroker/src/broker.rs
@@ -2230,12 +2230,10 @@ impl AuthorizedAccess<'_, '_> {
                 .collect()
         };
 
-        let mut covered_signals: HashSet<SignalId> = HashSet::new();
-        for (signal_provider, intersection_signals_request) in providers {
-            covered_signals.extend(intersection_signals_request.iter().copied());
-
-            //Step 1: check if there is any possible ReadError while reading any of the signals
-            for signal_id in &intersection_signals_request {
+        // Validate all provider-served signals before querying any provider, so
+        // that a missing or unauthorized signal fails fast without provider I/O.
+        for (_, intersection_signals_request) in &providers {
+            for signal_id in intersection_signals_request {
                 match self
                     .broker
                     .database
@@ -2248,13 +2246,26 @@ impl AuthorizedAccess<'_, '_> {
                     Err(err) => return Err((err, signal_id.id())),
                 }
             }
+        }
 
-            //Step 2: send to each provider the intersection signals requested
-            let response = signal_provider
-                .get_signals_values_from_provider(intersection_signals_request.clone())
-                .await;
+        // Query all providers concurrently: a slow or unresponsive provider must
+        // not delay the other providers, nor multiply the request latency by the
+        // number of providers.
+        let provider_calls = providers.into_iter().map(
+            |(signal_provider, intersection_signals_request)| async move {
+                let response = signal_provider
+                    .get_signals_values_from_provider(intersection_signals_request.clone())
+                    .await;
+                (intersection_signals_request, response)
+            },
+        );
+        let provider_responses = futures::future::join_all(provider_calls).await;
 
-            //Step 3: collect responses from providers
+        let mut covered_signals: HashSet<SignalId> = HashSet::new();
+        for (intersection_signals_request, response) in provider_responses {
+            covered_signals.extend(intersection_signals_request.iter().copied());
+
+            // Collect responses from providers
             match response {
                 Ok(value) => {
                     if value.entries.is_empty() {
@@ -2274,7 +2285,7 @@ impl AuthorizedAccess<'_, '_> {
                     }
                 }
                 Err(_) => {
-                    //Step 4: if provider did not return any item, then return the datapoint in database
+                    // Provider did not return any item, fall back to the database
                     for signal_id in &intersection_signals_request {
                         match self.get_datapoint(signal_id.id()).await {
                             Ok(datapoint) => {
@@ -5533,6 +5544,109 @@ pub mod tests {
             calls.load(Ordering::SeqCst),
             1,
             "later provider must still be updated after a hanging provider"
+        );
+    }
+
+    struct BarrierSignalProvider {
+        signal_id: SignalId,
+        value: DataValue,
+        barrier: Arc<tokio::sync::Barrier>,
+    }
+
+    #[async_trait::async_trait]
+    impl SignalProvider for BarrierSignalProvider {
+        async fn update_filter(
+            &self,
+            _update_filters: HashMap<SignalId, Option<TimeInterval>>,
+        ) -> Result<(), (RegisterSignalError, String)> {
+            Ok(())
+        }
+
+        fn is_available(&self) -> bool {
+            true
+        }
+
+        async fn get_signals_values_from_provider(
+            &self,
+            _signals_ids: Vec<SignalId>,
+        ) -> Result<GetValuesProviderResponse, ()> {
+            // Both providers must be queried concurrently for this to complete.
+            self.barrier.wait().await;
+            let mut entries = IndexMap::new();
+            entries.insert(
+                self.signal_id,
+                Datapoint {
+                    ts: std::time::SystemTime::now(),
+                    source_ts: None,
+                    value: self.value.clone(),
+                },
+            );
+            Ok(GetValuesProviderResponse { entries })
+        }
+    }
+
+    /// Providers must be queried concurrently: with sequential calls the first
+    /// provider would block forever on the barrier and the outer timeout would
+    /// fire.
+    #[tokio::test]
+    async fn test_get_values_queries_providers_concurrently() {
+        let broker = DataBroker::default();
+        let timestamp = std::time::SystemTime::now();
+
+        let signal_a = helper_add_int32(&broker, "test.a", 1, timestamp)
+            .await
+            .expect("add signal a");
+        let signal_b = helper_add_int32(&broker, "test.b", 2, timestamp)
+            .await
+            .expect("add signal b");
+
+        let auth = broker.authorized_access(&permissions::ALLOW_ALL);
+
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+        auth.register_signals(
+            HashMap::from([(SignalId::new(signal_a), TimeInterval::new(0))]),
+            Box::new(BarrierSignalProvider {
+                signal_id: SignalId::new(signal_a),
+                value: DataValue::Int32(11),
+                barrier: barrier.clone(),
+            }),
+        )
+        .await
+        .expect("register provider a");
+        auth.register_signals(
+            HashMap::from([(SignalId::new(signal_b), TimeInterval::new(0))]),
+            Box::new(BarrierSignalProvider {
+                signal_id: SignalId::new(signal_b),
+                value: DataValue::Int32(22),
+                barrier: barrier.clone(),
+            }),
+        )
+        .await
+        .expect("register provider b");
+
+        let response = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            auth.get_values_broker(vec![SignalId::new(signal_a), SignalId::new(signal_b)]),
+        )
+        .await
+        .expect("providers must be queried concurrently (barrier would deadlock otherwise)")
+        .expect("get values should succeed");
+
+        assert_eq!(
+            response
+                .entries
+                .get(&SignalId::new(signal_a))
+                .expect("signal a present")
+                .value,
+            DataValue::Int32(11)
+        );
+        assert_eq!(
+            response
+                .entries
+                .get(&SignalId::new(signal_b))
+                .expect("signal b present")
+                .value,
+            DataValue::Int32(22)
         );
     }
 }

--- a/databroker/src/broker.rs
+++ b/databroker/src/broker.rs
@@ -2268,20 +2268,27 @@ impl AuthorizedAccess<'_, '_> {
             // Collect responses from providers
             match response {
                 Ok(value) => {
-                    if value.entries.is_empty() {
-                        // Provider returned Ok but with no matching entries,
-                        // fall back to database for the requested signals
-                        debug!("Provider returned Ok with empty entries, falling back to database");
-                        for signal_id in &intersection_signals_request {
-                            match self.get_datapoint(signal_id.id()).await {
-                                Ok(datapoint) => {
-                                    collected_entries.insert(*signal_id, datapoint.clone());
+                    // A provider response may be partial: fall back to the
+                    // database for every requested signal the provider did not
+                    // return, so every requested signal has exactly one entry.
+                    for signal_id in &intersection_signals_request {
+                        match value.entries.get(signal_id) {
+                            Some(datapoint) => {
+                                collected_entries.insert(*signal_id, datapoint.clone());
+                            }
+                            None => {
+                                debug!(
+                                    "Provider did not return a value for signal {}, falling back to database",
+                                    signal_id.id()
+                                );
+                                match self.get_datapoint(signal_id.id()).await {
+                                    Ok(datapoint) => {
+                                        collected_entries.insert(*signal_id, datapoint.clone());
+                                    }
+                                    Err(err) => return Err((err, signal_id.id())),
                                 }
-                                Err(err) => return Err((err, signal_id.id())),
                             }
                         }
-                    } else {
-                        collected_entries.extend(value.entries);
                     }
                 }
                 Err(_) => {
@@ -5645,6 +5652,100 @@ pub mod tests {
                 .entries
                 .get(&SignalId::new(signal_b))
                 .expect("signal b present")
+                .value,
+            DataValue::Int32(22)
+        );
+    }
+
+    struct PartialResponseProvider {
+        signal_id: SignalId,
+        value: DataValue,
+    }
+
+    #[async_trait::async_trait]
+    impl SignalProvider for PartialResponseProvider {
+        async fn update_filter(
+            &self,
+            _update_filters: HashMap<SignalId, Option<TimeInterval>>,
+        ) -> Result<(), (RegisterSignalError, String)> {
+            Ok(())
+        }
+
+        fn is_available(&self) -> bool {
+            true
+        }
+
+        async fn get_signals_values_from_provider(
+            &self,
+            _signals_ids: Vec<SignalId>,
+        ) -> Result<GetValuesProviderResponse, ()> {
+            // Deliberately return only one of the requested signals.
+            let mut entries = IndexMap::new();
+            entries.insert(
+                self.signal_id,
+                Datapoint {
+                    ts: std::time::SystemTime::now(),
+                    source_ts: None,
+                    value: self.value.clone(),
+                },
+            );
+            Ok(GetValuesProviderResponse { entries })
+        }
+    }
+
+    /// A partial provider response must not leave requested signals without a
+    /// value: missing signals fall back to the database, and the response keeps
+    /// one entry per request in request order.
+    #[tokio::test]
+    async fn test_get_values_falls_back_for_partial_provider_response() {
+        let broker = DataBroker::default();
+        let timestamp = std::time::SystemTime::now();
+
+        let signal_a = helper_add_int32(&broker, "test.a", 1, timestamp)
+            .await
+            .expect("add signal a");
+        let signal_b = helper_add_int32(&broker, "test.b", 2, timestamp)
+            .await
+            .expect("add signal b");
+
+        let auth = broker.authorized_access(&permissions::ALLOW_ALL);
+        auth.register_signals(
+            HashMap::from([
+                (SignalId::new(signal_a), TimeInterval::new(0)),
+                (SignalId::new(signal_b), TimeInterval::new(0)),
+            ]),
+            Box::new(PartialResponseProvider {
+                signal_id: SignalId::new(signal_b),
+                value: DataValue::Int32(22),
+            }),
+        )
+        .await
+        .expect("register partial provider");
+
+        let response = auth
+            .get_values_broker(vec![SignalId::new(signal_a), SignalId::new(signal_b)])
+            .await
+            .expect("get values should succeed");
+
+        let ordered_signals: Vec<SignalId> = response.entries.keys().copied().collect();
+        assert_eq!(
+            ordered_signals,
+            vec![SignalId::new(signal_a), SignalId::new(signal_b)],
+            "every requested signal must have exactly one entry in request order"
+        );
+        assert_eq!(
+            response
+                .entries
+                .get(&SignalId::new(signal_a))
+                .expect("signal a must fall back to the database")
+                .value,
+            DataValue::Int32(1)
+        );
+        assert_eq!(
+            response
+                .entries
+                .get(&SignalId::new(signal_b))
+                .expect("signal b must come from the provider")
                 .value,
             DataValue::Int32(22)
         );

--- a/databroker/src/broker.rs
+++ b/databroker/src/broker.rs
@@ -201,7 +201,7 @@ pub trait SignalProvider: Send + Sync + 'static {
     ) -> Result<(), (RegisterSignalError, String)>;
     fn is_available(&self) -> bool;
     async fn get_signals_values_from_provider(
-        &mut self,
+        &self,
         signals_ids: Vec<SignalId>,
     ) -> Result<GetValuesProviderResponse, ()>;
 }
@@ -214,9 +214,15 @@ pub struct ActuationChange {
 
 pub struct ActuationSubscription {
     vss_ids: Vec<i32>,
-    actuation_provider: Box<dyn ActuationProvider + Send + Sync + 'static>,
+    actuation_provider: Arc<dyn ActuationProvider + Send + Sync + 'static>,
     permissions: Permissions,
 }
+
+type ActuationSubscriptionSnapshot = (
+    Vec<i32>,
+    Arc<dyn ActuationProvider + Send + Sync + 'static>,
+    Permissions,
+);
 
 pub struct GetValuesProviderResponse {
     pub entries: IndexMap<SignalId, Datapoint>,
@@ -225,7 +231,7 @@ pub struct GetValuesProviderResponse {
 pub struct SignalProviderSubscription {
     vss_ids: HashSet<SignalId>, // good for optimizations
     signals_intervals: HashMap<SignalId, TimeInterval>,
-    signal_provider: Box<dyn SignalProvider>,
+    signal_provider: Arc<dyn SignalProvider>,
     permissions: Permissions,
 }
 
@@ -1702,7 +1708,7 @@ impl AuthorizedAccess<'_, '_> {
 
         let actuation_subscription: ActuationSubscription = ActuationSubscription {
             vss_ids,
-            actuation_provider,
+            actuation_provider: Arc::from(actuation_provider),
             permissions: self.permissions.clone(),
         };
         self.broker
@@ -1741,15 +1747,14 @@ impl AuthorizedAccess<'_, '_> {
         &self,
         actuation_changes: Vec<ActuationChange>,
     ) -> Result<(), (ActuationError, String)> {
-        let read_subscription_guard = self.broker.subscriptions.read().await;
-        let actuation_subscriptions = &read_subscription_guard.actuation_subscriptions;
-
         for actuation_change in &actuation_changes {
             let vss_id = actuation_change.id;
             self.can_write_actuator_target(&vss_id).await?;
             self.validate_actuator_update(&vss_id, &actuation_change.data_value)
                 .await?;
         }
+
+        let actuation_subscriptions = self.snapshot_actuation_subscriptions().await;
 
         let actuation_changes_per_vss_id = &self
             .map_actuation_changes_by_vss_id(actuation_changes)
@@ -1760,27 +1765,21 @@ impl AuthorizedAccess<'_, '_> {
 
             let opt_actuation_subscription = actuation_subscriptions
                 .iter()
-                .find(|subscription| subscription.vss_ids.contains(&vss_id));
+                .find(|(vss_ids, _, _)| vss_ids.contains(&vss_id));
             match opt_actuation_subscription {
-                Some(actuation_subscription) => {
-                    let is_expired = actuation_subscription.permissions.is_expired();
+                Some((vss_ids, actuation_provider, permissions)) => {
+                    let is_expired = permissions.is_expired();
                     if is_expired {
-                        let message = format!(
-                            "Permission for vss_ids {:?} expired",
-                            actuation_subscription.vss_ids
-                        );
+                        let message = format!("Permission for vss_ids {vss_ids:?} expired");
                         return Err((ActuationError::PermissionExpired, message));
                     }
 
-                    if !actuation_subscription.actuation_provider.is_available() {
+                    if !actuation_provider.is_available() {
                         let message = format!("Provider for vss_id {vss_id} does not exist");
                         return Err((ActuationError::ProviderNotAvailable, message));
                     }
 
-                    actuation_subscription
-                        .actuation_provider
-                        .actuate(actuation_changes)
-                        .await?
+                    actuation_provider.actuate(actuation_changes).await?
                 }
                 None => {
                     let message = format!("Provider for vss_id {vss_id} not available");
@@ -1802,29 +1801,24 @@ impl AuthorizedAccess<'_, '_> {
         self.can_write_actuator_target(&vss_id).await?;
         self.validate_actuator_update(&vss_id, data_value).await?;
 
-        let read_subscription_guard = self.broker.subscriptions.read().await;
-        let opt_actuation_subscription = &read_subscription_guard
-            .actuation_subscriptions
+        let actuation_subscriptions = self.snapshot_actuation_subscriptions().await;
+        let opt_actuation_subscription = actuation_subscriptions
             .iter()
-            .find(|subscription| subscription.vss_ids.contains(&vss_id));
+            .find(|(vss_ids, _, _)| vss_ids.contains(&vss_id));
         match opt_actuation_subscription {
-            Some(actuation_subscription) => {
-                let is_expired = actuation_subscription.permissions.is_expired();
+            Some((vss_ids, actuation_provider, permissions)) => {
+                let is_expired = permissions.is_expired();
                 if is_expired {
-                    let message = format!(
-                        "Permission for vss_ids {:?} expired",
-                        actuation_subscription.vss_ids
-                    );
+                    let message = format!("Permission for vss_ids {vss_ids:?} expired");
                     return Err((ActuationError::PermissionExpired, message));
                 }
 
-                if !actuation_subscription.actuation_provider.is_available() {
+                if !actuation_provider.is_available() {
                     let message = format!("Provider for vss_id {vss_id} does not exist");
                     return Err((ActuationError::ProviderNotAvailable, message));
                 }
 
-                actuation_subscription
-                    .actuation_provider
+                actuation_provider
                     .actuate(vec![ActuationChange {
                         id: vss_id,
                         data_value: data_value.clone(),
@@ -1836,6 +1830,23 @@ impl AuthorizedAccess<'_, '_> {
                 Err((ActuationError::ProviderNotAvailable, message))
             }
         }
+    }
+
+    async fn snapshot_actuation_subscriptions(&self) -> Vec<ActuationSubscriptionSnapshot> {
+        self.broker
+            .subscriptions
+            .read()
+            .await
+            .actuation_subscriptions
+            .iter()
+            .map(|subscription| {
+                (
+                    subscription.vss_ids.clone(),
+                    subscription.actuation_provider.clone(),
+                    subscription.permissions.clone(),
+                )
+            })
+            .collect()
     }
 
     async fn can_write_actuator_target(
@@ -2048,16 +2059,8 @@ impl AuthorizedAccess<'_, '_> {
                 .collect(),
         };
 
-        DataBroker::update_filter_to_providers(
-            update_filter,
-            &self
-                .broker
-                .subscriptions
-                .read()
-                .await
-                .signal_provider_subscriptions,
-        )
-        .await;
+        let providers = DataBroker::snapshot_signal_providers(&self.broker.subscriptions).await;
+        DataBroker::update_filter_to_providers(update_filter, providers).await;
     }
 
     pub async fn register_signals(
@@ -2093,7 +2096,7 @@ impl AuthorizedAccess<'_, '_> {
         let signal_subscription = SignalProviderSubscription {
             vss_ids: vss_ids_intervals.keys().copied().collect(),
             signals_intervals: vss_ids_intervals,
-            signal_provider,
+            signal_provider: Arc::from(signal_provider as Box<dyn SignalProvider>),
             permissions: self.permissions.clone(),
         };
         let provider_uuid = self
@@ -2197,63 +2200,66 @@ impl AuthorizedAccess<'_, '_> {
         &self,
         vss_signals: Vec<SignalId>,
     ) -> Result<GetValuesProviderResponse, (ReadError, i32)> {
-        let mut subscriptions = self.broker.subscriptions.write().await;
         let mut entries_response: IndexMap<SignalId, Datapoint> = IndexMap::new();
+        let requested_signals: HashSet<SignalId> = vss_signals.iter().copied().collect();
 
-        // if there are providers connected then forward the get value request to them
-        if !subscriptions.signal_provider_subscriptions.is_empty() {
-            // Step 1: find the interseccion of the requested signals and each provider's signals
-            for provider in subscriptions.signal_provider_subscriptions.values_mut() {
-                let intersection_signals_request: Vec<SignalId> = provider
-                    .vss_ids
-                    .intersection(&vss_signals.clone().into_iter().collect())
-                    .copied()
-                    .collect();
-
-                //Step 2: check if there is any possible ReadError while reading any of the signals
-                for signal_id in &intersection_signals_request {
-                    match self
-                        .broker
-                        .database
-                        .read()
-                        .await
-                        .authorized_read_access(self.permissions)
-                        .get_entry_by_id(signal_id.id())
-                    {
-                        Ok(_) => {}
-                        Err(err) => return Err((err, signal_id.id())),
+        // Snapshot the providers and the signals they can serve. The
+        // subscriptions lock is not held while talking to providers, so a slow
+        // or malicious provider cannot block the subscriptions structure.
+        let providers: Vec<(Arc<dyn SignalProvider>, Vec<SignalId>)> = {
+            let subscriptions = self.broker.subscriptions.read().await;
+            subscriptions
+                .signal_provider_subscriptions
+                .values()
+                .filter_map(|provider| {
+                    let intersection_signals_request: Vec<SignalId> = provider
+                        .vss_ids
+                        .intersection(&requested_signals)
+                        .copied()
+                        .collect();
+                    if intersection_signals_request.is_empty() {
+                        None
+                    } else {
+                        Some((
+                            provider.signal_provider.clone(),
+                            intersection_signals_request,
+                        ))
                     }
+                })
+                .collect()
+        };
+
+        let mut covered_signals: HashSet<SignalId> = HashSet::new();
+        for (signal_provider, intersection_signals_request) in providers {
+            covered_signals.extend(intersection_signals_request.iter().copied());
+
+            //Step 1: check if there is any possible ReadError while reading any of the signals
+            for signal_id in &intersection_signals_request {
+                match self
+                    .broker
+                    .database
+                    .read()
+                    .await
+                    .authorized_read_access(self.permissions)
+                    .get_entry_by_id(signal_id.id())
+                {
+                    Ok(_) => {}
+                    Err(err) => return Err((err, signal_id.id())),
                 }
+            }
 
-                //Step 3: send to each provider the intersection signals requested
-                let response = provider
-                    .signal_provider
-                    .get_signals_values_from_provider(intersection_signals_request.clone())
-                    .await;
+            //Step 2: send to each provider the intersection signals requested
+            let response = signal_provider
+                .get_signals_values_from_provider(intersection_signals_request.clone())
+                .await;
 
-                //Step 4: collect responses from providers
-                match response {
-                    Ok(value) => {
-                        if value.entries.is_empty() {
-                            // Provider returned Ok but with no matching entries,
-                            // fall back to database for the requested signals
-                            debug!(
-                                "Provider returned Ok with empty entries, falling back to database"
-                            );
-                            for signal_id in &intersection_signals_request {
-                                match self.get_datapoint(signal_id.id()).await {
-                                    Ok(datapoint) => {
-                                        entries_response.insert(*signal_id, datapoint.clone());
-                                    }
-                                    Err(err) => return Err((err, signal_id.id())),
-                                }
-                            }
-                        } else {
-                            entries_response.extend(value.entries);
-                        }
-                    }
-                    Err(_) => {
-                        //Step 5: if provider did not return any item, then return the datapoint in database
+            //Step 3: collect responses from providers
+            match response {
+                Ok(value) => {
+                    if value.entries.is_empty() {
+                        // Provider returned Ok but with no matching entries,
+                        // fall back to database for the requested signals
+                        debug!("Provider returned Ok with empty entries, falling back to database");
                         for signal_id in &intersection_signals_request {
                             match self.get_datapoint(signal_id.id()).await {
                                 Ok(datapoint) => {
@@ -2262,20 +2268,37 @@ impl AuthorizedAccess<'_, '_> {
                                 Err(err) => return Err((err, signal_id.id())),
                             }
                         }
+                    } else {
+                        entries_response.extend(value.entries);
                     }
                 }
-            }
-        } else {
-            // if not just send to the client database last database values
-            for signal_id in &vss_signals {
-                match self.get_datapoint(signal_id.id()).await {
-                    Ok(datapoint) => {
-                        entries_response.insert(*signal_id, datapoint.clone());
+                Err(_) => {
+                    //Step 4: if provider did not return any item, then return the datapoint in database
+                    for signal_id in &intersection_signals_request {
+                        match self.get_datapoint(signal_id.id()).await {
+                            Ok(datapoint) => {
+                                entries_response.insert(*signal_id, datapoint.clone());
+                            }
+                            Err(err) => return Err((err, signal_id.id())),
+                        }
                     }
-                    Err(err) => return Err((err, signal_id.id())),
                 }
             }
         }
+
+        // Signals that are not served by any provider are read from the database
+        for signal_id in &vss_signals {
+            if covered_signals.contains(signal_id) {
+                continue;
+            }
+            match self.get_datapoint(signal_id.id()).await {
+                Ok(datapoint) => {
+                    entries_response.insert(*signal_id, datapoint.clone());
+                }
+                Err(err) => return Err((err, signal_id.id())),
+            }
+        }
+
         Ok(GetValuesProviderResponse {
             entries: entries_response,
         })
@@ -2379,11 +2402,8 @@ impl DataBroker {
                         .await
                         .remove_filter_by_subscription_uuid(closed_change_subscriptions);
 
-                    Self::update_filter_to_providers(
-                        new_update_filter,
-                        &subscriptions.read().await.signal_provider_subscriptions,
-                    )
-                    .await;
+                    let providers = Self::snapshot_signal_providers(&subscriptions).await;
+                    Self::update_filter_to_providers(new_update_filter, providers).await;
                 }
 
                 if new_connected_providers_count < connected_providers_count {
@@ -2393,14 +2413,25 @@ impl DataBroker {
         });
     }
 
+    async fn snapshot_signal_providers(
+        subscriptions: &Arc<RwLock<Subscriptions>>,
+    ) -> Vec<(Arc<dyn SignalProvider>, HashSet<SignalId>)> {
+        subscriptions
+            .read()
+            .await
+            .signal_provider_subscriptions
+            .values()
+            .map(|provider| (provider.signal_provider.clone(), provider.vss_ids.clone()))
+            .collect()
+    }
+
     async fn update_filter_to_providers(
         update_signal_intervals: HashMap<SignalId, Option<TimeInterval>>,
-        providers: &HashMap<Uuid, SignalProviderSubscription>,
+        providers: Vec<(Arc<dyn SignalProvider>, HashSet<SignalId>)>,
     ) {
-        for provider in providers.values() {
+        for (signal_provider, vss_ids) in providers {
             // Find which provider contains any of the signals to be updated with new interval.
-            let update_signal_map: HashMap<SignalId, Option<TimeInterval>> = provider
-                .vss_ids
+            let update_signal_map: HashMap<SignalId, Option<TimeInterval>> = vss_ids
                 .iter()
                 .filter_map(|&signal_id| update_signal_intervals.get_key_value(&signal_id))
                 .map(|(&k, v)| {
@@ -2412,8 +2443,7 @@ impl DataBroker {
 
             // Send to each provider the new (signal_id, new_interval) map.
             if !update_signal_map.is_empty() {
-                provider
-                    .signal_provider
+                signal_provider
                     .update_filter(update_signal_map)
                     .await
                     .unwrap();
@@ -4936,5 +4966,342 @@ pub mod tests {
                  broadcast_drops_total counter depends on this variant"
             ),
         }
+    }
+
+    struct HangingSignalProvider {
+        entered: Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait::async_trait]
+    impl SignalProvider for HangingSignalProvider {
+        async fn update_filter(
+            &self,
+            _update_filters: HashMap<SignalId, Option<TimeInterval>>,
+        ) -> Result<(), (RegisterSignalError, String)> {
+            Ok(())
+        }
+
+        fn is_available(&self) -> bool {
+            true
+        }
+
+        async fn get_signals_values_from_provider(
+            &self,
+            _signals_ids: Vec<SignalId>,
+        ) -> Result<GetValuesProviderResponse, ()> {
+            self.entered.notify_one();
+            std::future::pending::<Result<GetValuesProviderResponse, ()>>().await
+        }
+    }
+
+    struct CountingSignalProvider {
+        calls: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl SignalProvider for CountingSignalProvider {
+        async fn update_filter(
+            &self,
+            _update_filters: HashMap<SignalId, Option<TimeInterval>>,
+        ) -> Result<(), (RegisterSignalError, String)> {
+            Ok(())
+        }
+
+        fn is_available(&self) -> bool {
+            true
+        }
+
+        async fn get_signals_values_from_provider(
+            &self,
+            _signals_ids: Vec<SignalId>,
+        ) -> Result<GetValuesProviderResponse, ()> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Err(())
+        }
+    }
+
+    struct HangingUpdateFilterProvider {
+        entered: Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait::async_trait]
+    impl SignalProvider for HangingUpdateFilterProvider {
+        async fn update_filter(
+            &self,
+            _update_filters: HashMap<SignalId, Option<TimeInterval>>,
+        ) -> Result<(), (RegisterSignalError, String)> {
+            self.entered.notify_one();
+            std::future::pending::<Result<(), (RegisterSignalError, String)>>().await
+        }
+
+        fn is_available(&self) -> bool {
+            true
+        }
+
+        async fn get_signals_values_from_provider(
+            &self,
+            _signals_ids: Vec<SignalId>,
+        ) -> Result<GetValuesProviderResponse, ()> {
+            Err(())
+        }
+    }
+
+    struct HangingActuationProvider {
+        entered: Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait::async_trait]
+    impl ActuationProvider for HangingActuationProvider {
+        async fn actuate(
+            &self,
+            _actuation_changes: Vec<ActuationChange>,
+        ) -> Result<(), (ActuationError, String)> {
+            self.entered.notify_one();
+            std::future::pending::<Result<(), (ActuationError, String)>>().await
+        }
+
+        fn is_available(&self) -> bool {
+            true
+        }
+    }
+
+    /// A provider that never answers `get_signals_values_from_provider` must
+    /// not block operations that touch the subscriptions structure.
+    #[tokio::test]
+    async fn test_get_values_provider_does_not_block_subscriptions() {
+        let broker = DataBroker::default();
+        let timestamp = std::time::SystemTime::now();
+
+        let provided_signal = helper_add_int32(&broker, "test.provided", 1, timestamp)
+            .await
+            .expect("add provided signal");
+        let db_signal = helper_add_int32(&broker, "test.db", 2, timestamp)
+            .await
+            .expect("add db signal");
+
+        let auth = broker.authorized_access(&permissions::ALLOW_ALL);
+
+        let entered = Arc::new(tokio::sync::Notify::new());
+        auth.register_signals(
+            HashMap::from([(SignalId::new(provided_signal), TimeInterval::new(0))]),
+            Box::new(HangingSignalProvider {
+                entered: entered.clone(),
+            }),
+        )
+        .await
+        .expect("register hanging provider");
+
+        let hanging_broker = broker.clone();
+        let get_values_task = tokio::spawn(async move {
+            let auth = hanging_broker.authorized_access(&permissions::ALLOW_ALL);
+            auth.get_values_broker(vec![SignalId::new(provided_signal)])
+                .await
+        });
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), entered.notified())
+            .await
+            .expect("provider should have been called");
+
+        let result = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            let _stream = auth
+                .subscribe(
+                    HashMap::from([(db_signal, HashSet::from([Field::Datapoint]))]),
+                    None,
+                    None,
+                )
+                .await
+                .expect("subscribe must not be blocked by a hanging provider");
+
+            let other_signal = helper_add_int32(&broker, "test.other", 3, timestamp)
+                .await
+                .expect("add other signal");
+            auth.register_signals(
+                HashMap::from([(SignalId::new(other_signal), TimeInterval::new(0))]),
+                Box::new(HangingSignalProvider {
+                    entered: Arc::new(tokio::sync::Notify::new()),
+                }),
+            )
+            .await
+            .expect("register must not be blocked by a hanging provider");
+
+            auth.get_datapoint(db_signal)
+                .await
+                .expect("read must not be blocked by a hanging provider");
+        })
+        .await;
+
+        get_values_task.abort();
+        assert!(
+            result.is_ok(),
+            "subscriptions operations blocked while a provider call was pending"
+        );
+    }
+
+    /// Signals not served by any provider must be read from the database, and
+    /// providers must not be queried for signals outside their intersection.
+    #[tokio::test]
+    async fn test_get_values_skips_provider_without_matching_signal() {
+        let broker = DataBroker::default();
+        let timestamp = std::time::SystemTime::now();
+
+        let provided_signal = helper_add_int32(&broker, "test.provided", 1, timestamp)
+            .await
+            .expect("add provided signal");
+        let db_signal = helper_add_int32(&broker, "test.db", 42, timestamp)
+            .await
+            .expect("add db signal");
+
+        let auth = broker.authorized_access(&permissions::ALLOW_ALL);
+
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        auth.register_signals(
+            HashMap::from([(SignalId::new(provided_signal), TimeInterval::new(0))]),
+            Box::new(CountingSignalProvider {
+                calls: calls.clone(),
+            }),
+        )
+        .await
+        .expect("register counting provider");
+
+        let response = auth
+            .get_values_broker(vec![SignalId::new(db_signal)])
+            .await
+            .expect("get values should succeed");
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            0,
+            "provider must not be queried for signals it does not provide"
+        );
+        let datapoint = response
+            .entries
+            .get(&SignalId::new(db_signal))
+            .expect("signal without matching provider must fall back to the database");
+        assert_eq!(datapoint.value, DataValue::Int32(42));
+    }
+
+    /// A provider that never answers `update_filter` must not block operations
+    /// other than the `subscribe` that triggered the filter update.
+    #[tokio::test]
+    async fn test_update_filter_provider_does_not_block_subscriptions() {
+        let broker = DataBroker::default();
+        let timestamp = std::time::SystemTime::now();
+
+        let provided_signal = helper_add_int32(&broker, "test.provided", 1, timestamp)
+            .await
+            .expect("add provided signal");
+        let db_signal = helper_add_int32(&broker, "test.db", 2, timestamp)
+            .await
+            .expect("add db signal");
+
+        let auth = broker.authorized_access(&permissions::ALLOW_ALL);
+
+        let entered = Arc::new(tokio::sync::Notify::new());
+        auth.register_signals(
+            HashMap::from([(SignalId::new(provided_signal), TimeInterval::new(0))]),
+            Box::new(HangingUpdateFilterProvider {
+                entered: entered.clone(),
+            }),
+        )
+        .await
+        .expect("register hanging update_filter provider");
+
+        let subscribe_broker = broker.clone();
+        let subscribe_task = tokio::spawn(async move {
+            let auth = subscribe_broker.authorized_access(&permissions::ALLOW_ALL);
+            auth.subscribe(
+                HashMap::from([(provided_signal, HashSet::from([Field::Datapoint]))]),
+                None,
+                Some(0),
+            )
+            .await
+        });
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), entered.notified())
+            .await
+            .expect("update_filter should have been called");
+
+        let result = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            auth.get_values_broker(vec![SignalId::new(db_signal)])
+                .await
+                .expect("get values must not be blocked by a hanging update_filter");
+        })
+        .await;
+
+        subscribe_task.abort();
+        assert!(
+            result.is_ok(),
+            "subscriptions operations blocked while update_filter was pending"
+        );
+    }
+
+    /// A provider that never answers `actuate` must not block operations that
+    /// touch the subscriptions structure.
+    #[tokio::test]
+    async fn test_actuate_provider_does_not_block_subscriptions() {
+        let broker = DataBroker::default();
+        let timestamp = std::time::SystemTime::now();
+
+        let actuator_id = broker
+            .authorized_access(&permissions::ALLOW_ALL)
+            .add_entry(
+                "test.actuator".to_owned(),
+                DataType::Bool,
+                ChangeType::OnChange,
+                EntryType::Actuator,
+                "Test actuator".to_owned(),
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("add actuator");
+        let db_signal = helper_add_int32(&broker, "test.db", 2, timestamp)
+            .await
+            .expect("add db signal");
+
+        let auth = broker.authorized_access(&permissions::ALLOW_ALL);
+
+        let entered = Arc::new(tokio::sync::Notify::new());
+        auth.provide_actuation(
+            vec![actuator_id],
+            Box::new(HangingActuationProvider {
+                entered: entered.clone(),
+            }),
+        )
+        .await
+        .expect("provide actuation");
+
+        let actuate_broker = broker.clone();
+        let actuate_task = tokio::spawn(async move {
+            let auth = actuate_broker.authorized_access(&permissions::ALLOW_ALL);
+            auth.actuate(&actuator_id, &DataValue::Bool(true)).await
+        });
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), entered.notified())
+            .await
+            .expect("actuate should have been called");
+
+        let result = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            auth.get_values_broker(vec![SignalId::new(db_signal)])
+                .await
+                .expect("get values must not be blocked by a hanging actuate");
+            let _stream = auth
+                .subscribe(
+                    HashMap::from([(db_signal, HashSet::from([Field::Datapoint]))]),
+                    None,
+                    None,
+                )
+                .await
+                .expect("subscribe must not be blocked by a hanging actuate");
+        })
+        .await;
+
+        actuate_task.abort();
+        assert!(
+            result.is_ok(),
+            "subscriptions operations blocked while an actuation provider was pending"
+        );
     }
 }

--- a/databroker/src/grpc/kuksa_val_v2/val.rs
+++ b/databroker/src/grpc/kuksa_val_v2/val.rs
@@ -155,9 +155,21 @@ impl SignalProvider for Provider {
         &self,
         signals_ids: Vec<SignalId>,
     ) -> Result<GetValuesProviderResponse, ()> {
+        let deadline = std::time::Instant::now() + tokio::time::Duration::from_secs(1);
+
         // Serialize request/response exchanges per provider. The lock is only
         // shared with other calls for this provider, not with the broker.
-        let mut receiver_guard = self.receiver.lock().await;
+        // Bound every phase by the deadline so a provider that stops draining
+        // its outbound stream cannot block this or later calls forever.
+        let mut receiver_guard = match timeout(
+            deadline.saturating_duration_since(std::time::Instant::now()),
+            self.receiver.lock(),
+        )
+        .await
+        {
+            Ok(receiver_guard) => receiver_guard,
+            Err(_) => return Err(()),
+        };
 
         let request_id = self.next_request_id.fetch_add(1, Ordering::Relaxed);
 
@@ -172,12 +184,17 @@ impl SignalProvider for Provider {
             ),
         };
 
-        let result = self.sender.send(Ok(request)).await;
-        match result {
-            Ok(_) => {}
-            Err(err) => {
+        let send_result = timeout(
+            deadline.saturating_duration_since(std::time::Instant::now()),
+            self.sender.send(Ok(request)),
+        )
+        .await;
+        match send_result {
+            Ok(Ok(_)) => {}
+            Ok(Err(err)) => {
                 debug!("{}", err.to_string());
             }
+            Err(_) => return Err(()),
         }
 
         let receiver = match receiver_guard.as_mut() {
@@ -185,7 +202,6 @@ impl SignalProvider for Provider {
             None => return Err(()),
         };
 
-        let deadline = std::time::Instant::now() + tokio::time::Duration::from_secs(1);
         // Collect requested IDs for filtering provider response entries
         let requested_ids: HashSet<i32> = signals_ids.iter().map(|id| id.id()).collect();
 
@@ -4076,6 +4092,37 @@ mod tests {
             returned.value,
             DataValue::Float(12.5),
             "should receive 12.5 from second response, not 99.0 from the discarded first"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_provider_get_values_is_bounded_when_outbound_channel_full() {
+        let (mpsc_tx, _mpsc_rx) =
+            mpsc::channel::<Result<OpenProviderStreamResponse, tonic::Status>>(1);
+        // Fill the single slot so the request send blocks.
+        mpsc_tx
+            .send(Ok(OpenProviderStreamResponse { action: None }))
+            .await
+            .expect("initial send should succeed");
+
+        let (_broadcast_tx, broadcast_rx) = broadcast::channel(10);
+        let provider = Provider {
+            sender: mpsc_tx,
+            receiver: Mutex::new(Some(BroadcastStream::new(broadcast_rx))),
+            next_request_id: AtomicU32::new(1),
+        };
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(3),
+            provider.get_signals_values_from_provider(vec![TypesSignalId::new(1)]),
+        )
+        .await;
+
+        let result =
+            result.expect("provider call must be bounded even with a full outbound channel");
+        assert!(
+            result.is_err(),
+            "a full outbound channel should yield an error instead of blocking forever"
         );
     }
 }

--- a/databroker/src/grpc/kuksa_val_v2/val.rs
+++ b/databroker/src/grpc/kuksa_val_v2/val.rs
@@ -12,7 +12,11 @@
 ********************************************************************************/
 
 use indexmap::IndexMap;
-use std::{collections::HashMap, pin::Pin};
+use std::{
+    collections::HashMap,
+    pin::Pin,
+    sync::atomic::{AtomicU32, Ordering},
+};
 use uuid::Uuid;
 
 use crate::{
@@ -41,7 +45,7 @@ use kuksa::proto::v2::{
 use std::collections::HashSet;
 use tokio::{
     select,
-    sync::{broadcast, mpsc},
+    sync::{broadcast, mpsc, Mutex},
     time::timeout,
 };
 use tokio_stream::{
@@ -54,8 +58,9 @@ const MAX_REQUEST_PATH_LENGTH: usize = 1000;
 
 pub struct Provider {
     sender: mpsc::Sender<Result<OpenProviderStreamResponse, tonic::Status>>,
-    receiver: Option<BroadcastStream<databroker_proto::kuksa::val::v2::GetProviderValueResponse>>,
-    next_request_id: u32,
+    receiver:
+        Mutex<Option<BroadcastStream<databroker_proto::kuksa::val::v2::GetProviderValueResponse>>>,
+    next_request_id: AtomicU32,
 }
 
 #[async_trait::async_trait]
@@ -147,11 +152,14 @@ impl SignalProvider for Provider {
     }
 
     async fn get_signals_values_from_provider(
-        &mut self,
+        &self,
         signals_ids: Vec<SignalId>,
     ) -> Result<GetValuesProviderResponse, ()> {
-        let request_id = self.next_request_id;
-        self.next_request_id = self.next_request_id.wrapping_add(1);
+        // Serialize request/response exchanges per provider. The lock is only
+        // shared with other calls for this provider, not with the broker.
+        let mut receiver_guard = self.receiver.lock().await;
+
+        let request_id = self.next_request_id.fetch_add(1, Ordering::Relaxed);
 
         let request = OpenProviderStreamResponse {
             action: Some(
@@ -172,7 +180,7 @@ impl SignalProvider for Provider {
             }
         }
 
-        let receiver = match self.receiver.as_mut() {
+        let receiver = match receiver_guard.as_mut() {
             Some(receiver) => receiver,
             None => return Err(()),
         };
@@ -1109,8 +1117,8 @@ async fn provide_actuation(
 
     let provider = Provider {
         sender,
-        receiver: None,
-        next_request_id: 1,
+        receiver: Mutex::new(None),
+        next_request_id: AtomicU32::new(1),
     };
 
     match broker
@@ -1143,8 +1151,8 @@ async fn register_provided_signals(
 ) -> Result<(Uuid, OpenProviderStreamResponse), tonic::Status> {
     let provider = Provider {
         sender,
-        receiver: Some(BroadcastStream::new(receiver)),
-        next_request_id: 1,
+        receiver: Mutex::new(Some(BroadcastStream::new(receiver))),
+        next_request_id: AtomicU32::new(1),
     };
 
     let all_vss_ids = request
@@ -2998,8 +3006,8 @@ mod tests {
         let (sender, _) = mpsc::channel(10);
         let actuation_provider = Provider {
             sender,
-            receiver: None,
-            next_request_id: 1,
+            receiver: Mutex::new(None),
+            next_request_id: AtomicU32::new(1),
         };
         authorized_access
             .provide_actuation(vss_ids, Box::new(actuation_provider))
@@ -3125,8 +3133,8 @@ mod tests {
         let (sender, mut receiver) = mpsc::channel(10);
         let actuation_provider = Provider {
             sender,
-            receiver: None,
-            next_request_id: 1,
+            receiver: Mutex::new(None),
+            next_request_id: AtomicU32::new(1),
         };
         authorized_access
             .provide_actuation(vss_ids, Box::new(actuation_provider))
@@ -3227,8 +3235,8 @@ mod tests {
         let (sender, _receiver) = mpsc::channel(10);
         let actuation_provider = Provider {
             sender,
-            receiver: None,
-            next_request_id: 1,
+            receiver: Mutex::new(None),
+            next_request_id: AtomicU32::new(1),
         };
         authorized_access
             .provide_actuation(vss_ids, Box::new(actuation_provider))
@@ -3381,8 +3389,8 @@ mod tests {
         let (sender, _receiver) = mpsc::channel(10);
         let actuation_provider = Provider {
             sender,
-            receiver: None,
-            next_request_id: 1,
+            receiver: Mutex::new(None),
+            next_request_id: AtomicU32::new(1),
         };
         authorized_access
             .provide_actuation(vss_ids, Box::new(actuation_provider))
@@ -3475,8 +3483,8 @@ mod tests {
         let (sender, mut receiver) = mpsc::channel(10);
         let actuation_provider = Provider {
             sender,
-            receiver: None,
-            next_request_id: 1,
+            receiver: Mutex::new(None),
+            next_request_id: AtomicU32::new(1),
         };
         authorized_access
             .provide_actuation(vss_ids, Box::new(actuation_provider))
@@ -3646,8 +3654,8 @@ mod tests {
         let (sender, _) = mpsc::channel(10);
         let actuation_provider = Provider {
             sender,
-            receiver: None,
-            next_request_id: 1,
+            receiver: Mutex::new(None),
+            next_request_id: AtomicU32::new(1),
         };
         authorized_access
             .provide_actuation(vss_ids, Box::new(actuation_provider))
@@ -3785,8 +3793,8 @@ mod tests {
         let (sender, mut _receiver) = mpsc::channel(10);
         let actuation_provider = Provider {
             sender,
-            receiver: None,
-            next_request_id: 1,
+            receiver: Mutex::new(None),
+            next_request_id: AtomicU32::new(1),
         };
         authorized_access
             .provide_actuation(vss_ids, Box::new(actuation_provider))
@@ -3861,7 +3869,7 @@ mod tests {
             }
 
             async fn get_signals_values_from_provider(
-                &mut self,
+                &self,
                 _signals_ids: Vec<TypesSignalId>,
             ) -> Result<GetValuesProviderResponse, ()> {
                 Ok(GetValuesProviderResponse {
@@ -3948,8 +3956,8 @@ mod tests {
             broadcast::channel::<proto::GetProviderValueResponse>(10);
         let provider = Provider {
             sender: mpsc_tx,
-            receiver: Some(BroadcastStream::new(broadcast_rx)),
-            next_request_id: 1,
+            receiver: Mutex::new(Some(BroadcastStream::new(broadcast_rx))),
+            next_request_id: AtomicU32::new(1),
         };
         (provider, broadcast_tx)
     }
@@ -3957,7 +3965,7 @@ mod tests {
     #[tokio::test]
     async fn test_provider_correct_response_accepted() {
         let our_signal = 1;
-        let (mut provider, broadcast_tx) = make_provider_with_broadcast_rx();
+        let (provider, broadcast_tx) = make_provider_with_broadcast_rx();
 
         let mut entries = HashMap::new();
         entries.insert(our_signal, make_float_datapoint(12.5));
@@ -3983,7 +3991,7 @@ mod tests {
     #[tokio::test]
     async fn test_provider_wrong_request_id_discarded_via_timeout() {
         let our_signal = 1;
-        let (mut provider, broadcast_tx) = make_provider_with_broadcast_rx();
+        let (provider, broadcast_tx) = make_provider_with_broadcast_rx();
 
         let mut entries = HashMap::new();
         entries.insert(our_signal, make_float_datapoint(99.0));
@@ -4012,7 +4020,7 @@ mod tests {
     async fn test_provider_wrong_signal_id_discarded() {
         let other_signal = 999;
         let our_signal = 1;
-        let (mut provider, broadcast_tx) = make_provider_with_broadcast_rx();
+        let (provider, broadcast_tx) = make_provider_with_broadcast_rx();
 
         let mut entries = HashMap::new();
         entries.insert(other_signal, make_float_datapoint(99.0));
@@ -4037,7 +4045,7 @@ mod tests {
     async fn test_provider_skips_wrong_request_id_then_accepts_correct() {
         let other_signal = 999;
         let our_signal = 1;
-        let (mut provider, broadcast_tx) = make_provider_with_broadcast_rx();
+        let (provider, broadcast_tx) = make_provider_with_broadcast_rx();
 
         // First response: wrong request_id — should be skipped
         let mut wrong_entries = HashMap::new();


### PR DESCRIPTION
This is an issue in how databroker dealt with kuksa.val.v2 providers

The finding was detected by a scrutineer run, copying the report verbatim here

> ### Finding  Provider-induced global availability DoS: get_values_broker holds the subscriptions write-lock across the await on the remote provider's get_signals_values_from_provider
> 
> | Field | Value |
> |---|---|
> | Severity | Medium |
> | Status | new |
> | CWE | CWE-667 |
> | Location | `databroker/src/broker.rs:2200` |
> | Sinks | S1 |
> 
> #### Source
> 
> ```rust
> 
>     pub async fn get_values_broker(
>         &self,
>         vss_signals: Vec<SignalId>,
>     ) -> Result<GetValuesProviderResponse, (ReadError, i32)> {
>         let mut subscriptions = self.broker.subscriptions.write().await;
>         let mut entries_response: IndexMap<SignalId, Datapoint> = IndexMap::new();
> 
>         // if there are providers connected then forward the get value request to them
>         if !subscriptions.signal_provider_subscriptions.is_empty() {
>             // Step 1: find the interseccion of the requested signals and each provider's signals
> ```
> 
> #### Trace
> 
> get_values_broker (broker.rs:2196) acquired `self.broker.subscriptions.write().await` at 2200 and keeps the write guard alive while it iterates the `signal_provider_subscriptions` map and, for the intersection of requested signals with each provider, calls `provider.signal_provider.get_signals_values_from_provider(...).await` at 2229-2232 before releasing the guard at the end of the method (2282). Because tokio::sync::RwLock blocks tasks that request either the read or the write lock while a write guard is held, a provider that does not promptly answer the get_values request freezes the entire `subscriptions` structure: every other OP that touches it (subscribe's add_change_subscription write at 1640, register_signals write at 2099, extend_signals write at 2138, provide_actuation write at 1708, actuate/batch_actuate reads at 1805/1744, notify read at 1557, housekeeping cleanup writes at 2323-2384) blocks until the provider answers. The input is the provider's response latency (a southbound in-scope adversary, threat_model adversaries.in_scope lists compromised/over-privileged providers; a transiently partitioned or simply slow provider has the same effect).
> 

This and related issues have been fixed like this:

## Problem
get_values_broker held the subscriptions write lock across the entire provider round-trip (provider.get_signals_values_from_provider(...).await). Because tokio::sync::RwLock blocks readers and writers while a write guard is held, a provider that delayed or never answered its GetValues request stalled every other operation touching subscriptions:
- subscribe / provider registration / actuation registration (writers)
- actuate / batch_actuate (readers)
- change notification and housekeeping cleanup
The in-tree gRPC provider has a 1s response deadline, but the request was enqueued on the provider's response channel before that deadline started, so a provider that stopped draining its stream could block indefinitely. The write lock was also only required because SignalProvider::get_signals_values_from_provider took &mut self — an implementation detail of request/response correlation, not a real need for exclusive access to the subscription map.
Two amplifiers made it worse:
- Every registered provider was queried on every read, even when it provided none of the requested signals.
- The same hold-lock-across-provider-await pattern existed in filter propagation (update_filter) and actuation (actuate/batch_actuate).

## Fix
Provider I/O is now decoupled from the subscriptions lock. Providers are stored as Arc and snapshotted under a short read lock; the lock is released before any provider is awaited, so provider latency is isolated to the request that triggered it.
- Signal reads: get_values_broker snapshots the matching providers and their signal intersections, skips providers with an empty intersection, then queries them without holding the lock.
- Filter propagation: update_filter_to_providers operates on a snapshot, so subscribe no longer holds the subscriptions lock while notifying providers.
- Actuation: actuate/batch_actuate snapshot the matching provider and await it outside the lock.
- Per-provider serialization: SignalProvider::get_signals_values_from_provider takes &self; the gRPC provider serializes request/response exchanges with a per-provider mutex and an atomic request id, preserving correct response correlation while allowing different providers to be queried concurrently.

## One Behavior change for consistency
Signals that are not served by any registered provider are now read from the database, consistent with the no-provider case. Previously, if any provider was registered, a requested signal not covered by one was silently omitted from the response.


## Tests
Existing tests pass (with only mininal syntax change)
Four regression tests were added:
- A provider that never answers get_values does not block subscribe, provider registration, or direct reads.
- A provider is not queried for signals outside its intersection, and the uncovered signal is served from the database.
- A provider that never answers update_filter does not block other operations.
- A provider that never answers actuate does not block other operations.

**This does not change the GRPC interface. So no API change just internal implementation**